### PR TITLE
Add initialiser for lib2 

### DIFF
--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    implementation("org.bytedeco:javacv-platform:1.5.7")
 }
 
 tasks.test {

--- a/DifferenceGenerator/src/main/kotlin/AbstractDifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/AbstractDifferenceGenerator.kt
@@ -1,3 +1,6 @@
+import org.bytedeco.javacv.FFmpegFrameGrabber
+import java.awt.image.BufferedImage
+
 /**
  * Abstract class for the DifferenceGenerator.
  *
@@ -5,35 +8,29 @@
  * @param video2Path the path to the second video
  * @param outputPath the path to the output file
  */
-
-abstract class AbstractDifferenceGenerator(video1Path: String, video2Path: String, outputPath: String) {
-    private val video1Path: String = video1Path
-    private val video2Path: String = video2Path
-    private val outputPath: String = outputPath
-
-    /**
-     * Loads the video1 and video2 files into memory.
-     * Saves them into local variables.
-     *
-     * Calls the generateDifference() method!!!
-     *
-     * @return the video1Path
-     */
-    abstract fun init()
+abstract class AbstractDifferenceGenerator(
+    video1Path: String,
+    video2Path: String,
+    outputPath: String,
+) {
+    val video1Path: String = video1Path
+    val video2Path: String = video2Path
+    val outputPath: String = outputPath
 
     /**
      * Generates the difference between the two videos.
      *
      * Calls the saveDifferences() method.
-     *
-     *
      */
-    abstract fun generateDifference()
+    abstract fun generateDifference(
+        oldFileGrabber: FFmpegFrameGrabber,
+        newFileGrabber: FFmpegFrameGrabber,
+    )
 
     /**
      * Saves the differences to the output file.
      *
      * @return the video1Path
      */
-    abstract fun saveDifferences()
+    abstract fun saveDifferences(differences: List<BufferedImage>)
 }

--- a/DifferenceGenerator/src/main/kotlin/AbstractDifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/AbstractDifferenceGenerator.kt
@@ -1,6 +1,3 @@
-import org.bytedeco.javacv.FFmpegFrameGrabber
-import java.awt.image.BufferedImage
-
 /**
  * Abstract class for the DifferenceGenerator.
  *
@@ -22,15 +19,12 @@ abstract class AbstractDifferenceGenerator(
      *
      * Calls the saveDifferences() method.
      */
-    abstract fun generateDifference(
-        oldFileGrabber: FFmpegFrameGrabber,
-        newFileGrabber: FFmpegFrameGrabber,
-    )
+    abstract fun generateDifference()
 
     /**
      * Saves the differences to the output file.
      *
      * @return the video1Path
      */
-    abstract fun saveDifferences(differences: List<BufferedImage>)
+    abstract fun saveDifferences()
 }

--- a/DifferenceGenerator/src/main/kotlin/AcceptedCodecs.kt
+++ b/DifferenceGenerator/src/main/kotlin/AcceptedCodecs.kt
@@ -5,6 +5,15 @@
 class AcceptedCodecs {
     companion object {
         val ACCEPTED_CODECS =
-            listOf("ffv1", "YUV", "flashsv", "gif", "png", "tiff", "ljpeg", "Uncompressed")
+            setOf(
+                "ffv1",
+                "YUV",
+                "flashsv",
+                "gif",
+                "png",
+                "tiff",
+                "ljpeg",
+                "Uncompressed YUV 422 10-bit",
+            )
     }
 }

--- a/DifferenceGenerator/src/main/kotlin/AcceptedCodecs.kt
+++ b/DifferenceGenerator/src/main/kotlin/AcceptedCodecs.kt
@@ -1,0 +1,10 @@
+/**
+ * A globally accessible object that contains a list of all accepted codecs. This list can be
+ * expanded to include more codecs.
+ */
+class AcceptedCodecs {
+    companion object {
+        val ACCEPTED_CODECS =
+            listOf("ffv1", "YUV", "flashsv", "gif", "png", "tiff", "ljpeg", "Uncompressed")
+    }
+}

--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -1,5 +1,4 @@
 import org.bytedeco.javacv.FFmpegFrameGrabber
-import java.awt.image.BufferedImage
 import java.io.File
 
 class DifferenceGenerator(video1Path: String, video2Path: String, outputPath: String) :
@@ -8,32 +7,30 @@ class DifferenceGenerator(video1Path: String, video2Path: String, outputPath: St
     val video1File = File(video1Path)
     val video2File = File(video2Path)
 
+    val video1Grabber = FFmpegFrameGrabber(video1File)
+    val video2Grabber = FFmpegFrameGrabber(video2File)
+
     /**
      * Initializes a new instance of the [DifferenceGenerator] class.
      *
      * @throws Exception if the videos are not in an [AcceptedCodecs.ACCEPTED_CODECS].
      */
     init {
-        if (isLosslessCodec(video1File) && isLosslessCodec(video2File)) {
-            val video1Grabber = FFmpegFrameGrabber(video1File)
-            val video2Grabber = FFmpegFrameGrabber(video2File)
-
-            generateDifference(video1Grabber, video2Grabber)
-        } else {
+        if (!isLosslessCodec(video1Grabber) || !isLosslessCodec(video2Grabber)) {
             throw Exception("Videos must be in a lossless codec")
         }
+        generateDifference()
     }
 
     /**
      * Determines whether the given video file is encoded using one of the
      * [AcceptedCodecs.ACCEPTED_CODECS].
      *
-     * @param videoFile the video file to check
+     * @param [FFmpegFrameGrabber] of the video to check
      * @return true if the video file is encoded using one of the [AcceptedCodecs.ACCEPTED_CODECS],
      * false otherwise
      */
-    private fun isLosslessCodec(videoFile: File): Boolean {
-        val grabber = FFmpegFrameGrabber(videoFile)
+    private fun isLosslessCodec(grabber: FFmpegFrameGrabber): Boolean {
         grabber.start()
         val codecName = grabber.videoMetadata["encoder"]
         grabber.stop()
@@ -41,18 +38,10 @@ class DifferenceGenerator(video1Path: String, video2Path: String, outputPath: St
             throw Exception("Video must have a codec")
         }
 
-        for (codec in AcceptedCodecs.ACCEPTED_CODECS) {
-            if (codecName.contains(codec)) {
-                return true
-            }
-        }
-        return false
+        return codecName in AcceptedCodecs.ACCEPTED_CODECS
     }
 
-    override fun generateDifference(
-        oldFileGrabber: FFmpegFrameGrabber,
-        newFileGrabber: FFmpegFrameGrabber,
-    ) {}
+    override fun generateDifference() {}
 
-    override fun saveDifferences(differences: List<BufferedImage>) {}
+    override fun saveDifferences() {}
 }

--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -1,0 +1,58 @@
+import org.bytedeco.javacv.FFmpegFrameGrabber
+import java.awt.image.BufferedImage
+import java.io.File
+
+class DifferenceGenerator(video1Path: String, video2Path: String, outputPath: String) :
+    AbstractDifferenceGenerator(video1Path, video2Path, outputPath) {
+    val outputFile = File(outputPath)
+    val video1File = File(video1Path)
+    val video2File = File(video2Path)
+
+    /**
+     * Initializes a new instance of the [DifferenceGenerator] class.
+     *
+     * @throws Exception if the videos are not in an [AcceptedCodecs.ACCEPTED_CODECS].
+     */
+    init {
+        if (isLosslessCodec(video1File) && isLosslessCodec(video2File)) {
+            val video1Grabber = FFmpegFrameGrabber(video1File)
+            val video2Grabber = FFmpegFrameGrabber(video2File)
+
+            generateDifference(video1Grabber, video2Grabber)
+        } else {
+            throw Exception("Videos must be in a lossless codec")
+        }
+    }
+
+    /**
+     * Determines whether the given video file is encoded using one of the
+     * [AcceptedCodecs.ACCEPTED_CODECS].
+     *
+     * @param videoFile the video file to check
+     * @return true if the video file is encoded using one of the [AcceptedCodecs.ACCEPTED_CODECS],
+     * false otherwise
+     */
+    private fun isLosslessCodec(videoFile: File): Boolean {
+        val grabber = FFmpegFrameGrabber(videoFile)
+        grabber.start()
+        val codecName = grabber.videoMetadata["encoder"]
+        grabber.stop()
+        if (codecName == null) {
+            throw Exception("Video must have a codec")
+        }
+
+        for (codec in AcceptedCodecs.ACCEPTED_CODECS) {
+            if (codecName.contains(codec)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun generateDifference(
+        oldFileGrabber: FFmpegFrameGrabber,
+        newFileGrabber: FFmpegFrameGrabber,
+    ) {}
+
+    override fun saveDifferences(differences: List<BufferedImage>) {}
+}

--- a/DifferenceGenerator/src/main/kotlin/Main.kt
+++ b/DifferenceGenerator/src/main/kotlin/Main.kt
@@ -1,5 +1,9 @@
 fun main(args: Array<String>) {
     println("Hello World!")
-
+    DifferenceGenerator(
+        "src/main/resources/uncompressedWater.mov",
+        "src/main/resources/uncompressedWater.mov",
+        "src/main/resources/output.mov",
+    )
     println("Program arguments: ${args.joinToString()}")
 }


### PR DESCRIPTION
Closes #6 
This PR adds a non abstract implementation of the AbstractDifferenceGenerator. 
It only implements the initialiser which is supposed to check wether the input files are encoded lossless.
This already required a comprehensive library, I used javaCV because it can be imported only by adding it to the `gradle.build.kts` file and nothing has to be installed manually.
I hardcoded accepted video codecs as a globally accessible object. The list of codecs is not yet fully evaluated and can be edited after further discussing with _esolutions_. I think it makes sense to agree to a couple of codecs and enforce them.

