### PR TITLE
add ktlint config file that ignores code in prototype directory.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# Apply standard rules to all Kotlin files
+[*.{kt,kts}]
+ktlint_standard = enabled
+# Ignore code in Prototype directory
+[Prototypes/**/*.kt]
+ktlint_standard = disabled


### PR DESCRIPTION
Previously, the git commit hook failed due to the code in the Prototype folder. Commiting was only possible using `git commit --no-verify ...`.
Now, the folder is ignored.