### PR TITLE
feat(lib2): resettable frame converter

### DIFF
--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -4,7 +4,6 @@ import org.bytedeco.ffmpeg.global.avcodec.AV_CODEC_ID_FFV1
 import org.bytedeco.javacv.FFmpegFrameGrabber
 import org.bytedeco.javacv.FFmpegFrameRecorder
 import org.bytedeco.javacv.Frame
-import org.bytedeco.javacv.Java2DFrameConverter
 import java.awt.Color
 import java.awt.Graphics2D
 import java.awt.image.BufferedImage
@@ -22,6 +21,8 @@ class DifferenceGenerator(
 
     private val video1Grabber = FFmpegFrameGrabber(video1File)
     private val video2Grabber = FFmpegFrameGrabber(video2File)
+
+    private val converter = Resettable2DFrameConverter()
 
     private var width = 0
     private var height = 0
@@ -137,8 +138,7 @@ class DifferenceGenerator(
             }
         }
 
-        val converterOutput = Java2DFrameConverter()
-        return converterOutput.getFrame(differences, 1.0)
+        return converter.getFrame(differences)
     }
 
     /**
@@ -151,8 +151,7 @@ class DifferenceGenerator(
         val images = ArrayList<BufferedImage>()
         var frame = grabber.grabImage()
         while (frame != null) {
-            val converter = Java2DFrameConverter()
-            images.add(converter.convert(frame))
+            images.add(converter.getImage(frame))
             frame = grabber.grabImage()
         }
         return images.toTypedArray()
@@ -165,8 +164,7 @@ class DifferenceGenerator(
      * @return a frame colored in the given color
      */
     private fun getColoredFrame(color: Color): Frame {
-        val converterOutput = Java2DFrameConverter()
-        return converterOutput.getFrame(getColoredBufferedImage(color), 1.0)
+        return converter.getFrame(getColoredBufferedImage(color))
     }
 
     /**

--- a/DifferenceGenerator/src/main/kotlin/Resettable2DFrameConverter.kt
+++ b/DifferenceGenerator/src/main/kotlin/Resettable2DFrameConverter.kt
@@ -1,0 +1,21 @@
+import org.bytedeco.javacv.Frame
+import org.bytedeco.javacv.Java2DFrameConverter
+import java.awt.image.BufferedImage
+
+class Resettable2DFrameConverter : Java2DFrameConverter() {
+    private fun reset() {
+        this.bufferedImage = null
+    }
+
+    fun getImage(frame: Frame): BufferedImage {
+        val img = super.getBufferedImage(frame)
+        this.reset()
+        return img
+    }
+
+    override fun getFrame(image: BufferedImage): Frame {
+        val frame = super.getFrame(image, 1.0)
+        this.reset()
+        return frame
+    }
+}


### PR DESCRIPTION
extends the Java2DFrameConverter to reset its internal state after a conversion, so that the instance can be reused without side effects.

This is not closing any ticket, rather came up in several discussions (#42, #69)