### PR TITLE
fix(lib1): Determine image size from first frame and not pass it explicitly in the constructor.

### DIFF
--- a/VideoGenerator/example/app/src/main/java/de/guiframediff/videogeneratorexample/MainActivity.kt
+++ b/VideoGenerator/example/app/src/main/java/de/guiframediff/videogeneratorexample/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : ComponentActivity() {
     private val handler = Handler(Looper.getMainLooper())
     private val random = Random()
     private lateinit var randomTextView: TextView
-    private val videoGenerator = VideoGeneratorImpl("test.gif", 1920, 720)
+    private val videoGenerator = VideoGeneratorImpl("test.gif")
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/VideoGenerator/library/.gitignore
+++ b/VideoGenerator/library/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/local.properties
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/VideoGenerator/library/src/main/kotlin/AbstractVideoGenerator.kt
+++ b/VideoGenerator/library/src/main/kotlin/AbstractVideoGenerator.kt
@@ -3,11 +3,9 @@
  * Extend this class to create your own video generator.
  *
  * @param videoPath Output filesystem path for the resulting video.
- * @param imageWidth Horizontal number of pixels to be expected in images.
- * @param imageHeight Vertical number of pixels to be expected in images.
  */
 
-abstract class AbstractVideoGenerator(videoPath: String, imageWidth: Int, imageHeight: Int) {
+abstract class AbstractVideoGenerator(videoPath: String) {
     /**
      * Endpoint to load images into the generator.
      *

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorImplTests.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorImplTests.kt
@@ -21,7 +21,7 @@ class VideoGeneratorImplTests {
 
     @BeforeEach
     fun setUp() {
-        videoGenerator = VideoGeneratorImpl(videoPath, 640, 480)
+        videoGenerator = VideoGeneratorImpl(videoPath)
         exampleImageData1 = Files.readAllBytes(Paths.get("src/resources/Screenshot_50.png"))
         exampleImageData2 = Files.readAllBytes(Paths.get("src/resources/Screenshot_51.png"))
         exampleImageData3 = Files.readAllBytes(Paths.get("src/resources/Screenshot_52.png"))


### PR DESCRIPTION
Until now, the image size was given explicitly to the videogenarator. I think this is unnecessary and also leads to typos and thus to distorted images (if the ratio does not match).
