### PR TITLE
feat(license): use gradle plugin to perform license check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ bin/
 # DifferenceGenerator test resources
 # Videos are too large, please download from our drive
 DifferenceGenerator/src/test/resources/
+
+# License check reports
+licenses/reports/*

--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -1,6 +1,12 @@
+import com.github.jk1.license.filter.DependencyFilter
+import com.github.jk1.license.filter.LicenseBundleNormalizer
+import com.github.jk1.license.render.InventoryHtmlReportRenderer
+import com.github.jk1.license.render.ReportRenderer
+
 plugins {
     kotlin("jvm") version "1.8.0"
     application
+    id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
 group = "org.example"
@@ -25,4 +31,11 @@ kotlin {
 
 application {
     mainClass.set("MainKt")
+}
+
+licenseReport {
+    outputDir = "../licenses/reports/DifferenceGenerator"
+    renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "DifferenceGenerator"))
+    filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+    allowedLicensesFile = File("../licenses/allowed-licenses.json")
 }

--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -1,10 +1,16 @@
+import com.github.jk1.license.filter.DependencyFilter
+import com.github.jk1.license.filter.LicenseBundleNormalizer
+import com.github.jk1.license.render.InventoryHtmlReportRenderer
+import com.github.jk1.license.render.ReportRenderer
 import org.jetbrains.compose.compose
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+
 plugins {
     kotlin("jvm")
     id("org.jetbrains.compose")
+    id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
 group = "com.example"
@@ -48,4 +54,11 @@ tasks.register<Jar>("createRunnableJar") {
     }
     archiveFileName.set("GUI-Runnable.jar")
     destinationDirectory.set(file("$buildDir/libs"))
+}
+
+licenseReport {
+    outputDir = "../licenses/reports/GUI"
+    renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "GUI"))
+    filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+    allowedLicensesFile = File("../licenses/allowed-licenses.json")
 }

--- a/README.md
+++ b/README.md
@@ -34,3 +34,22 @@ We have a pre-commit hook that runs ktlint. Please activate it as follows:
 
 It makes sense to run `ktlint` more often to prevent a lot of formatting errors from piling up.
 It is also encouraged to use an on-save formatter as provided by IDEs like IntelliJ, Android Studio and VS Code.
+
+### License Checking
+
+The project uses a [gradle plugin](https://github.com/jk1/Gradle-License-Report) to generate
+dependency license reports. The reports are all saved in the `./licenses/reports/` directory.
+Currently, we are allowing the licenses `MIT` and `Apache 2.0`. This information can be changed
+in `./licenses/allowed-licenses.json`
+
+For `lib1`:
+- *to be implemented*
+
+For `lib2` (analogous for the `gui`):
+- Run a task that fails if dependencies with non-allowed licenses are found.
+- `cd ./DifferenceGenerator/ && ./gradlew checkLicense`
+- Generate a license report in html
+- `cd ./DifferenceGenerator/ && ./gradlew generateLicenseReport`
+- The report will be available at `./licenses/reports/DifferenceGenerator/`
+
+

--- a/licenses/allowed-licenses.json
+++ b/licenses/allowed-licenses.json
@@ -1,25 +1,10 @@
 {
   "allowedLicenses": [
     {
-      "moduleLicense": "Apache License, Version 2.0",
-      "moduleName": "org.jetbrains.kotlin:kotlin-stdlib",
-      "moduleVersion": "1.2.60"
-    },
-    {
-      "moduleLicense": "Apache License, Version 2.0",
-      "moduleName": "org.jetbrains.kotlin*",
-      "moduleVersion": ".*"
-    },
-    {
-      "moduleLicense": "MIT License",
-      "moduleName": ".*"
+      "moduleLicense": "Apache License, Version 2.0"
     },
     {
       "moduleLicense": "MIT License"
-    },
-    {
-      "moduleLicense": "MIT License",
-      "moduleName": ""
     }
   ]
 }

--- a/licenses/allowed-licenses.json
+++ b/licenses/allowed-licenses.json
@@ -1,0 +1,25 @@
+{
+  "allowedLicenses": [
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": "org.jetbrains.kotlin:kotlin-stdlib",
+      "moduleVersion": "1.2.60"
+    },
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": "org.jetbrains.kotlin*",
+      "moduleVersion": ".*"
+    },
+    {
+      "moduleLicense": "MIT License",
+      "moduleName": ".*"
+    },
+    {
+      "moduleLicense": "MIT License"
+    },
+    {
+      "moduleLicense": "MIT License",
+      "moduleName": ""
+    }
+  ]
+}


### PR DESCRIPTION
This uses the gradle plugin available at https://github.com/jk1/Gradle-License-Report. So far only tested for lib2 (DifferenceGenerator).

I will open this for merge, when the plugin can be applied to the other two subprojects