### PR TITLE
tests for reading a frame and writing a frame

### DIFF
--- a/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
@@ -20,13 +20,13 @@ internal class ReadRuntimeTests {
 
     private val methodMap: Map<String, (Resettable2DFrameConverter, Frame, Frame, Int, Int) -> Int> =
         mapOf(
-//            "BufferedImage" to ::method1,
+            "BufferedImage" to ::method1,
             "Raster" to ::method2,
             "ByteArray with 'xor'" to ::method3,
             "ByteArray with 'and'" to ::method4,
             "ByteArray with 'and' + extra var" to ::method5,
             "ByteArray with 'and' + less vars" to ::method6,
-//            "ByteArray with indexedMap" to ::method7,
+            "ByteArray with indexedMap" to ::method7,
             "ByteArray with single loop" to ::method8,
             "ByteArray with single while loop" to ::method9,
         )

--- a/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
@@ -27,7 +27,7 @@ internal class ReadRuntimeTests {
             "ByteArray with 'and' + extra var" to ::method5,
             "ByteArray with 'and' + less vars" to ::method6,
             "ByteArray with indexedMap" to ::method7,
-            "ByteArray with whole color" to ::method8,
+            "ByteArray with single loop" to ::method8,
         )
 
     private fun averageRunTime(

--- a/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
@@ -16,7 +16,7 @@ internal class ReadRuntimeTests {
     private val modifiedVideo9Frames = resourcesPathPrefix + "9ScreenshotsModified.mov"
     private val video1File = File(video9Frames)
     private val video2File = File(modifiedVideo9Frames)
-    private val runAmount = 50
+    private val runAmount = 20
 
     private val methodMap: Map<String, (Resettable2DFrameConverter, Frame, Frame, Int, Int) -> Int> =
         mapOf(
@@ -27,6 +27,7 @@ internal class ReadRuntimeTests {
             "ByteArray with 'and' + extra var" to ::method5,
             "ByteArray with 'and' + less vars" to ::method6,
             "ByteArray with indexedMap" to ::method7,
+            "ByteArray with whole color" to ::method8,
         )
 
     private fun averageRunTime(
@@ -288,6 +289,32 @@ internal class ReadRuntimeTests {
                     byte == data2[index]
                 }.filter { !it }
             ).size
+        return counter
+    }
+
+    private fun method8(
+        converter: Resettable2DFrameConverter,
+        frame1: Frame,
+        frame2: Frame,
+        width: Int,
+        height: Int,
+    ): Int {
+        var counter = 0
+        val data1 = (converter.getImage(frame1).raster.dataBuffer as DataBufferByte).data
+        val data2 = (converter.getImage(frame2).raster.dataBuffer as DataBufferByte).data
+        for (index in 0 until height * width * 3 step 3) {
+            val blue1 = data1[index] and 0xFF.toByte()
+            val green1 = data1[index + 1] and 0xFF.toByte()
+            val red1 = data1[index + 2] and 0xFF.toByte()
+
+            val blue2 = data2[index] and 0xFF.toByte()
+            val green2 = data2[index + 1] and 0xFF.toByte()
+            val red2 = data2[index + 2] and 0xFF.toByte()
+
+            if (blue1 != blue2 || green1 != green2 || red1 != red2) {
+                counter++
+            }
+        }
         return counter
     }
 }

--- a/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
@@ -20,14 +20,15 @@ internal class ReadRuntimeTests {
 
     private val methodMap: Map<String, (Resettable2DFrameConverter, Frame, Frame, Int, Int) -> Int> =
         mapOf(
-            "BufferedImage" to ::method1,
+//            "BufferedImage" to ::method1,
             "Raster" to ::method2,
             "ByteArray with 'xor'" to ::method3,
             "ByteArray with 'and'" to ::method4,
             "ByteArray with 'and' + extra var" to ::method5,
             "ByteArray with 'and' + less vars" to ::method6,
-            "ByteArray with indexedMap" to ::method7,
+//            "ByteArray with indexedMap" to ::method7,
             "ByteArray with single loop" to ::method8,
+            "ByteArray with single while loop" to ::method9,
         )
 
     private fun averageRunTime(
@@ -314,6 +315,35 @@ internal class ReadRuntimeTests {
             if (blue1 != blue2 || green1 != green2 || red1 != red2) {
                 counter++
             }
+        }
+        return counter
+    }
+
+    private fun method9(
+        converter: Resettable2DFrameConverter,
+        frame1: Frame,
+        frame2: Frame,
+        width: Int,
+        height: Int,
+    ): Int {
+        var counter = 0
+        val data1 = (converter.getImage(frame1).raster.dataBuffer as DataBufferByte).data
+        val data2 = (converter.getImage(frame2).raster.dataBuffer as DataBufferByte).data
+        var index = 0
+        while (index < height * width * 3) {
+
+            val blue1 = data1[index] and 0xFF.toByte()
+            val green1 = data1[index + 1] and 0xFF.toByte()
+            val red1 = data1[index + 2] and 0xFF.toByte()
+
+            val blue2 = data2[index] and 0xFF.toByte()
+            val green2 = data2[index + 1] and 0xFF.toByte()
+            val red2 = data2[index + 2] and 0xFF.toByte()
+
+            if (blue1 != blue2 || green1 != green2 || red1 != red2) {
+                counter++
+            }
+            index += 3
         }
         return counter
     }

--- a/DifferenceGenerator/src/test/kotlin/WriteRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/WriteRuntimeTests.kt
@@ -16,6 +16,7 @@ internal class WriteRuntimeTests {
             "Raster" to ::method2,
             "DataBuffer" to ::method3,
             "DataBuffer single loop" to ::method4,
+            "DataBuffer while loop" to ::method5,
         )
 
     private fun averageRunTime(
@@ -91,6 +92,17 @@ internal class WriteRuntimeTests {
         val dataBuffer = bufferedImage.raster.dataBuffer
         for (index in 0 until size * size) {
             dataBuffer.setElem(index, 0xFFFFFF)
+        }
+        return converter.getFrame(bufferedImage)
+    }
+
+    private fun method5(converter: Resettable2DFrameConverter): Frame {
+        val bufferedImage = BufferedImage(size, size, BufferedImage.TYPE_3BYTE_BGR)
+        val dataBuffer = bufferedImage.raster.dataBuffer
+        var index = 0
+        while (index < size * size) {
+            dataBuffer.setElem(index, 0xFFFFFF)
+            index++
         }
         return converter.getFrame(bufferedImage)
     }

--- a/DifferenceGenerator/src/test/kotlin/WriteRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/WriteRuntimeTests.kt
@@ -1,0 +1,97 @@
+import org.bytedeco.javacv.Frame
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+import kotlin.system.measureTimeMillis
+
+// maybe an interface for the methods?
+
+internal class WriteRuntimeTests {
+    private val runAmount = 50
+    private val size = 6000
+
+    private val methodMap: Map<String, (Resettable2DFrameConverter) -> Frame> =
+        mapOf(
+            "BufferedImage" to ::method1,
+            "Raster" to ::method2,
+            "DataBuffer" to ::method3,
+            "DataBuffer single loop" to ::method4,
+        )
+
+    private fun averageRunTime(
+        runs: Int = runAmount,
+        methodName: String,
+    ) {
+        var totalTime = 0L
+        val method = methodMap[methodName] ?: throw Exception("Method not found")
+        for (i in 0 until runs) {
+            totalTime += wrapper(method)
+        }
+        println("Average for $methodName: ${totalTime / runs} ms")
+    }
+
+    @Test
+    fun `test pixel comparison`() {
+        for (method in methodMap.keys) {
+            averageRunTime(methodName = method)
+        }
+    }
+
+    private fun wrapper(method: (Resettable2DFrameConverter) -> Frame): Long {
+        val converter = Resettable2DFrameConverter()
+        var f: Frame
+        val time =
+            measureTimeMillis {
+                f = method(converter)
+            }
+        if (f.imageWidth != size || f.imageHeight != size) {
+            throw Exception("Wrong size")
+        }
+
+        if (converter.convert(f).getRGB(0, 0) != Color.WHITE.rgb) {
+            throw Exception("Wrong color")
+        }
+        return time
+    }
+
+    private fun method1(converter: Resettable2DFrameConverter): Frame {
+        val bufferedImage = BufferedImage(size, size, BufferedImage.TYPE_3BYTE_BGR)
+        for (x in 0 until size) {
+            for (y in 0 until size) {
+                bufferedImage.setRGB(x, y, 0xFFFFFF)
+            }
+        }
+        return converter.getFrame(bufferedImage)
+    }
+
+    private fun method2(converter: Resettable2DFrameConverter): Frame {
+        val bufferedImage = BufferedImage(size, size, BufferedImage.TYPE_3BYTE_BGR)
+        val raster = bufferedImage.raster
+        for (x in 0 until size) {
+            for (y in 0 until size) {
+                raster.setPixel(x, y, intArrayOf(0xFF, 0xFF, 0xFF))
+            }
+        }
+        return converter.getFrame(bufferedImage)
+    }
+
+    private fun method3(converter: Resettable2DFrameConverter): Frame {
+        val bufferedImage = BufferedImage(size, size, BufferedImage.TYPE_3BYTE_BGR)
+        val dataBuffer = bufferedImage.raster.dataBuffer
+        for (x in 0 until size) {
+            for (y in 0 until size) {
+                dataBuffer.setElem(x * size + y, 0xFFFFFF)
+            }
+        }
+        return converter.getFrame(bufferedImage)
+    }
+
+    private fun method4(converter: Resettable2DFrameConverter): Frame {
+        val bufferedImage = BufferedImage(size, size, BufferedImage.TYPE_3BYTE_BGR)
+        val dataBuffer = bufferedImage.raster.dataBuffer
+        for (index in 0 until size * size) {
+            dataBuffer.setElem(index, 0xFFFFFF)
+        }
+        return converter.getFrame(bufferedImage)
+    }
+}


### PR DESCRIPTION
reading a frame is optimal for bytearray with single loop:

![image](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/a4c788df-8d45-4f8d-841a-c0ff023d9c3a)


same goes for writing to a frame:
![Screenshot_214](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/2fb78d5c-1541-4be0-a3c7-4f883f15fa30)


Confirm this decision for refactoring the DifferenceGeneratorClass 