### PR TITLE
Lib1 performance comparison tests with different codecs

### DIFF
--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorBenchmarkTest.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorBenchmarkTest.kt
@@ -10,7 +10,7 @@ import kotlin.math.log10
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
 
-class VideoGeneratorStressTest {
+class VideoGeneratorBenchmarkTest {
     private lateinit var videoGenerator: VideoGeneratorImpl
     private val videoPath = "src/resources/testOutput.mkv"
     private val inputPath = "../example/app/src/androidTest/assets/screen"

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorImpl.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorImpl.kt
@@ -11,9 +11,12 @@ import javax.imageio.ImageIO
  * @param videoPath The path to the output video file.
  */
 class VideoGeneratorImpl(
-    private val videoPath: String,
+    private val videoPath: String
 ) : AbstractVideoGenerator(videoPath) {
     private lateinit var recorder: FFmpegFrameRecorder
+    var codecId: Int = avcodec.AV_CODEC_ID_FFV1
+    var videoFormat: String = "matroska"
+    var codecOptions: Map<String, String> = mapOf("" to "")
 
     /**
      * Loads a frame from the given byte array.
@@ -96,8 +99,10 @@ class VideoGeneratorImpl(
         imageWidth: Int,
         imageHeight: Int,
     ) = FFmpegFrameRecorder(videoPath, imageWidth, imageHeight).apply {
-        videoCodec = avcodec.AV_CODEC_ID_FFV1
-        format = "matroska"
+        videoCodec = codecId
+        format = videoFormat
         frameRate = 25.0
+        videoOptions = codecOptions
     }
+
 }

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorImpl.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorImpl.kt
@@ -11,7 +11,7 @@ import javax.imageio.ImageIO
  * @param videoPath The path to the output video file.
  */
 class VideoGeneratorImpl(
-    private val videoPath: String
+    private val videoPath: String,
 ) : AbstractVideoGenerator(videoPath) {
     private lateinit var recorder: FFmpegFrameRecorder
     var codecId: Int = avcodec.AV_CODEC_ID_FFV1
@@ -104,5 +104,4 @@ class VideoGeneratorImpl(
         frameRate = 25.0
         videoOptions = codecOptions
     }
-
 }

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorStressTest.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorStressTest.kt
@@ -1,10 +1,8 @@
+import org.bytedeco.ffmpeg.global.avcodec
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.bytedeco.ffmpeg.global.avcodec
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.io.File
 import java.lang.Exception
 import java.text.DecimalFormat
@@ -13,22 +11,21 @@ import kotlin.math.pow
 import kotlin.system.measureTimeMillis
 
 class VideoGeneratorStressTest {
-
-
     private lateinit var videoGenerator: VideoGeneratorImpl
     private val videoPath = "src/resources/testOutput.mkv"
     private val inputPath = "../example/app/src/androidTest/assets/screen"
-    private val testCodecs = mapOf<Int, Map<String, String>?>(
-        avcodec.AV_CODEC_ID_FFV1 to null,
-        //avcodec.AV_CODEC_ID_YUV4 to null,
-        //avcodec.AV_CODEC_ID_H265 to null,
-        avcodec.AV_CODEC_ID_VP9 to mapOf<String, String>("lossless" to "1"),
-        //avcodec.AV_CODEC_ID_VP8 to mapOf<String,String>("lossless" to "1"),
-        //avcodec.AV_CODEC_ID_VP9 to null,
-        //avcodec.AV_CODEC_ID_H264 to mapOf<String, String>("crf" to "0"),
-        //avcodec.AV_CODEC_ID_SNOW to null,
-        //avcodec.AV_CODEC_ID_JPEG2000 to mapOf<String, String>("pred" to "1")
-    )
+    private val testCodecs =
+        mapOf<Int, Map<String, String>?>(
+            avcodec.AV_CODEC_ID_FFV1 to null,
+            // avcodec.AV_CODEC_ID_YUV4 to null,
+            // avcodec.AV_CODEC_ID_H265 to null,
+            avcodec.AV_CODEC_ID_VP9 to mapOf<String, String>("lossless" to "1"),
+            // avcodec.AV_CODEC_ID_VP8 to mapOf<String,String>("lossless" to "1"),
+            // avcodec.AV_CODEC_ID_VP9 to null,
+            // avcodec.AV_CODEC_ID_H264 to mapOf<String, String>("crf" to "0"),
+            // avcodec.AV_CODEC_ID_SNOW to null,
+            // avcodec.AV_CODEC_ID_JPEG2000 to mapOf<String, String>("pred" to "1")
+        )
     private val testSizes = arrayOf(10, 100, 500, 800, 1000)
 
     @BeforeEach
@@ -60,18 +57,19 @@ class VideoGeneratorStressTest {
     private fun loadNFrames(n: Int = 100) {
         var combinedFileSize = 0L
         try {
-            val time = measureTimeMillis {
-                var i = 0
-                while (i < n) {
-                    val randomFrame = getRandomFrame(inputPath)
-                    if (randomFrame != null) {
-                        combinedFileSize += randomFrame.length()
-                        videoGenerator.loadFrame(randomFrame.readBytes())
+            val time =
+                measureTimeMillis {
+                    var i = 0
+                    while (i < n) {
+                        val randomFrame = getRandomFrame(inputPath)
+                        if (randomFrame != null) {
+                            combinedFileSize += randomFrame.length()
+                            videoGenerator.loadFrame(randomFrame.readBytes())
+                        }
+                        i++
                     }
-                    i++
+                    videoGenerator.save()
                 }
-                videoGenerator.save()
-            }
             val video = File(videoPath)
             assertTrue(video.exists())
             println("Codec: ${avcodec.avcodec_get_name(videoGenerator.codecId).string}")
@@ -79,14 +77,14 @@ class VideoGeneratorStressTest {
             println(
                 "File size reduced from ${readableFileSize(combinedFileSize)} to ${
                     readableFileSize(
-                        video.length()
+                        video.length(),
                     )
                 } (${
                     String.format(
                         "%.1f",
-                        video.length().toDouble() / combinedFileSize.toDouble() * 100
+                        video.length().toDouble() / combinedFileSize.toDouble() * 100,
                     )
-                }%)"
+                }%)",
             )
         } catch (e: Exception) {
             println("Codec: ${avcodec.avcodec_get_name(videoGenerator.codecId).string}")
@@ -94,7 +92,6 @@ class VideoGeneratorStressTest {
             e.printStackTrace()
             assertTrue(false)
         }
-
     }
 
     private fun getRandomFrame(path: String): File? {
@@ -107,7 +104,7 @@ class VideoGeneratorStressTest {
         val units = arrayOf("B", "kB", "MB", "GB", "TB")
         val digitGroups = (log10(size.toDouble()) / log10(1024.0)).toInt()
         return DecimalFormat("#,##0.#").format(
-            size / 1024.0.pow(digitGroups.toDouble())
+            size / 1024.0.pow(digitGroups.toDouble()),
         ) + " " + units[digitGroups]
     }
 }

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorStressTest.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorStressTest.kt
@@ -1,0 +1,78 @@
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.text.DecimalFormat
+import kotlin.math.log10
+import kotlin.math.pow
+import kotlin.system.measureTimeMillis
+
+
+class VideoGeneratorStressTest {
+
+
+    private lateinit var videoGenerator: VideoGeneratorImpl
+    private val videoPath = "src/resources/testOutput.mkv"
+    private val inputPath = "../example/app/src/androidTest/assets/screen"
+    private val testSizes = arrayOf(10, 100, 500, 800, 1000)
+
+    @BeforeEach
+    fun setUp() {
+        videoGenerator = VideoGeneratorImpl(videoPath)
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        File(videoPath).delete()
+        videoGenerator = VideoGeneratorImpl(videoPath)
+    }
+
+    @Test
+    fun stressTest() {
+        for (size in testSizes) {
+            loadNFrames(size)
+            cleanUp()
+        }
+    }
+
+    fun loadNFrames(n: Int) {
+        var combinedFileSize = 0L
+        val time = measureTimeMillis {
+            var i = 0
+            while (i < n) {
+                val randomFrame = getRandomFrame(inputPath)
+                if (randomFrame != null) {
+                    combinedFileSize += randomFrame.length()
+                    videoGenerator.loadFrame(randomFrame.readBytes())
+                }
+                i++
+            }
+            videoGenerator.save()
+        }
+        val video = File(videoPath)
+        assertTrue(video.exists())
+        println("Loading $n Files took $time ms (${time / n} ms / frame)")
+        println(
+            "File size reduced from ${readableFileSize(combinedFileSize)} to ${
+                readableFileSize(
+                    video.length()
+                )
+            } (${video.length() / combinedFileSize}%)"
+        )
+    }
+
+    fun getRandomFrame(path: String): File? {
+        val inputDir = File(path)
+        return inputDir.listFiles()?.random()
+    }
+
+    fun readableFileSize(size: Long): String {
+        if (size <= 0) return "0"
+        val units = arrayOf("B", "kB", "MB", "GB", "TB")
+        val digitGroups = (log10(size.toDouble()) / log10(1024.0)).toInt()
+        return DecimalFormat("#,##0.#").format(
+            size / 1024.0.pow(digitGroups.toDouble())
+        ) + " " + units[digitGroups]
+    }
+}

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorStressTest.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorStressTest.kt
@@ -1,13 +1,16 @@
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.bytedeco.ffmpeg.global.avcodec
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.File
+import java.lang.Exception
 import java.text.DecimalFormat
 import kotlin.math.log10
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
-
 
 class VideoGeneratorStressTest {
 
@@ -15,6 +18,17 @@ class VideoGeneratorStressTest {
     private lateinit var videoGenerator: VideoGeneratorImpl
     private val videoPath = "src/resources/testOutput.mkv"
     private val inputPath = "../example/app/src/androidTest/assets/screen"
+    private val testCodecs = mapOf<Int, Map<String, String>?>(
+        avcodec.AV_CODEC_ID_FFV1 to null,
+        //avcodec.AV_CODEC_ID_YUV4 to null,
+        //avcodec.AV_CODEC_ID_H265 to null,
+        avcodec.AV_CODEC_ID_VP9 to mapOf<String, String>("lossless" to "1"),
+        //avcodec.AV_CODEC_ID_VP8 to mapOf<String,String>("lossless" to "1"),
+        //avcodec.AV_CODEC_ID_VP9 to null,
+        //avcodec.AV_CODEC_ID_H264 to mapOf<String, String>("crf" to "0"),
+        //avcodec.AV_CODEC_ID_SNOW to null,
+        //avcodec.AV_CODEC_ID_JPEG2000 to mapOf<String, String>("pred" to "1")
+    )
     private val testSizes = arrayOf(10, 100, 500, 800, 1000)
 
     @BeforeEach
@@ -30,44 +44,65 @@ class VideoGeneratorStressTest {
 
     @Test
     fun stressTest() {
-        for (size in testSizes) {
-            loadNFrames(size)
-            cleanUp()
-        }
-    }
-
-    fun loadNFrames(n: Int) {
-        var combinedFileSize = 0L
-        val time = measureTimeMillis {
-            var i = 0
-            while (i < n) {
-                val randomFrame = getRandomFrame(inputPath)
-                if (randomFrame != null) {
-                    combinedFileSize += randomFrame.length()
-                    videoGenerator.loadFrame(randomFrame.readBytes())
+        for (codec in testCodecs) {
+            for (size in testSizes) {
+                videoGenerator.codecId = codec.key
+                if (codec.value != null) {
+                    videoGenerator.codecOptions = codec.value!!
                 }
-                i++
+                loadNFrames(size)
+                cleanUp()
             }
-            videoGenerator.save()
         }
-        val video = File(videoPath)
-        assertTrue(video.exists())
-        println("Loading $n Files took $time ms (${time / n} ms / frame)")
-        println(
-            "File size reduced from ${readableFileSize(combinedFileSize)} to ${
-                readableFileSize(
-                    video.length()
-                )
-            } (${video.length() / combinedFileSize}%)"
-        )
     }
 
-    fun getRandomFrame(path: String): File? {
+    @Test
+    private fun loadNFrames(n: Int = 100) {
+        var combinedFileSize = 0L
+        try {
+            val time = measureTimeMillis {
+                var i = 0
+                while (i < n) {
+                    val randomFrame = getRandomFrame(inputPath)
+                    if (randomFrame != null) {
+                        combinedFileSize += randomFrame.length()
+                        videoGenerator.loadFrame(randomFrame.readBytes())
+                    }
+                    i++
+                }
+                videoGenerator.save()
+            }
+            val video = File(videoPath)
+            assertTrue(video.exists())
+            println("Codec: ${avcodec.avcodec_get_name(videoGenerator.codecId).string}")
+            println("Loading $n Files took $time ms (${time / n} ms / frame)")
+            println(
+                "File size reduced from ${readableFileSize(combinedFileSize)} to ${
+                    readableFileSize(
+                        video.length()
+                    )
+                } (${
+                    String.format(
+                        "%.1f",
+                        video.length().toDouble() / combinedFileSize.toDouble() * 100
+                    )
+                }%)"
+            )
+        } catch (e: Exception) {
+            println("Codec: ${avcodec.avcodec_get_name(videoGenerator.codecId).string}")
+            println(e.localizedMessage)
+            e.printStackTrace()
+            assertTrue(false)
+        }
+
+    }
+
+    private fun getRandomFrame(path: String): File? {
         val inputDir = File(path)
         return inputDir.listFiles()?.random()
     }
 
-    fun readableFileSize(size: Long): String {
+    private fun readableFileSize(size: Long): String {
         if (size <= 0) return "0"
         val units = arrayOf("B", "kB", "MB", "GB", "TB")
         val digitGroups = (log10(size.toDouble()) / log10(1024.0)).toInt()


### PR DESCRIPTION
```
Codec: ffv1
Loading 10 Files took 1241 ms (124 ms / frame)
File size reduced from 2.3 MB to 1.9 MB (83.3%)

Codec: ffv1
Loading 100 Files took 6059 ms (60 ms / frame)
File size reduced from 23.6 MB to 18.3 MB (77.6%)

Codec: ffv1
Loading 500 Files took 29272 ms (58 ms / frame)
File size reduced from 113.2 MB to 86.1 MB (76.1%)

Codec: ffv1
Loading 800 Files took 45525 ms (56 ms / frame)
File size reduced from 173.3 MB to 133.4 MB (77.0%)

Codec: ffv1
Loading 1000 Files took 58758 ms (58 ms / frame)
File size reduced from 220.6 MB to 169.7 MB (76.9%)


Codec: vp9
Loading 10 Files took 1804 ms (180 ms / frame)
File size reduced from 2.7 MB to 1.5 MB (54.2%)

Codec: vp9
Loading 100 Files took 17195 ms (171 ms / frame)
File size reduced from 24 MB to 13.7 MB (57.1%)

Codec: vp9
Loading 500 Files took 88192 ms (176 ms / frame)
File size reduced from 114.6 MB to 63 MB (55.0%)

Codec: vp9
Loading 800 Files took 138997 ms (173 ms / frame)
File size reduced from 179.1 MB to 102.6 MB (57.3%)

Codec: vp9
Loading 1000 Files took 164804 ms (164 ms / frame)
File size reduced from 225.4 MB to 129.7 MB (57.6%)
```
