### PR TITLE
ci: init lint and test workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,11 @@
+root = true
+
 # Apply standard rules to all Kotlin files
 [*.{kt,kts}]
+ktlint_code_style = ktlint_official
 ktlint_standard = enabled
+indent_size = 4
+indent_style = space
 
 # Ignore code in Prototype directory
 [Prototypes/**/*.kt]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  ktlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # from the ktlint wiki page https://pinterest.github.io/ktlint/1.0.1/install/cli/
+      - run: curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.0.1/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/
+      - run: ktlint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,32 @@ on:
       - main
   pull_request:
 jobs:
+  lib1:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./VideoGenerator/example
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Run the Gradle package task
+        uses: gradle/gradle-build-action@v2
+
+      - name: Give exec permission for ./gradlew
+        run: chmod +x ./gradlew
+      - name: Assemble the apk
+        run: ./gradlew assemble
+      - name: Download test assets
+        run: ./gradlew downloadAndUnzipTestAssets
+      - name: Run Tests
+        run: ./gradlew test
   lib2:
     runs-on: ubuntu-latest
     defaults:
@@ -12,7 +38,7 @@ jobs:
         working-directory: ./DifferenceGenerator
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+          cache: 'gradle'
+          cache-dependency-path: |
+            ./VideoGenerator/example/*.gradle*
+            ./VideoGenerator/example/**/gradle-wrapper.properties
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Run the Gradle package task
-        uses: gradle/gradle-build-action@v2
 
       - name: Give exec permission for ./gradlew
         run: chmod +x ./gradlew
@@ -42,10 +42,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Run the Gradle package task
-        uses: gradle/gradle-build-action@v2
+          cache: 'gradle'
+          cache-dependency-path: |
+            ./DifferenceGenerator/*.gradle*
+            ./DifferenceGenerator/**/gradle-wrapper.properties
 
       - name: Download test assets
         run: ./gradlew downloadAndUnzipTestAssets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  lib2:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./DifferenceGenerator
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Run the Gradle package task
+        uses: gradle/gradle-build-action@v2
+
+      - name: Download test assets
+        run: ./gradlew downloadAndUnzipTestAssets
+      - name: Run Tests
+        run: ./gradlew test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Give exec permission for ./gradlew
         run: chmod +x ./gradlew
       - name: Assemble the apk
-        run: ./gradlew assemble
+        run: ./gradlew assembleDebug assembleAndroidTest
       - name: Download test assets
         run: ./gradlew downloadAndUnzipTestAssets
       - name: Run Tests

--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 }
 
 tasks.test {
-    useJUnitPlatform()
+    useJUnitPlatform { excludeTags("benchmark") }
     systemProperty("gapOpenPenalty", System.getProperty("gapOpenPenalty") ?: "-0.5")
     systemProperty("gapExtensionPenalty", System.getProperty("gapExtensionPenalty") ?: "-0.5")
 }

--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -3,6 +3,7 @@ import algorithms.AlignmentElement
 import mask.CompositeMask
 import mask.Mask
 import org.bytedeco.ffmpeg.global.avcodec.AV_CODEC_ID_FFV1
+import org.bytedeco.ffmpeg.global.avutil
 import org.bytedeco.javacv.FFmpegFrameRecorder
 import org.bytedeco.javacv.Frame
 import wrappers.MaskedImageGrabber
@@ -64,6 +65,9 @@ class DifferenceGenerator(
 
         video1Grabber.mask = mask
         video2Grabber.mask = mask
+
+        // turn off verbose ffmpeg output
+        avutil.av_log_set_level(avutil.AV_LOG_QUIET)
 
         generateDifference()
     }

--- a/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
@@ -1,5 +1,6 @@
 import org.bytedeco.javacv.FFmpegFrameGrabber
 import org.bytedeco.javacv.Frame
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import wrappers.Resettable2DFrameConverter
 import java.awt.image.DataBufferByte
@@ -11,6 +12,7 @@ import kotlin.system.measureTimeMillis
 
 // maybe an interface for the methods?
 
+@Tag("benchmark")
 internal class ReadRuntimeTests {
     private val resourcesPathPrefix = "src/test/resources/"
     private val video9Frames = resourcesPathPrefix + "9Screenshots.mov"

--- a/DifferenceGenerator/src/test/kotlin/WriteRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/WriteRuntimeTests.kt
@@ -1,4 +1,5 @@
 import org.bytedeco.javacv.Frame
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import wrappers.Resettable2DFrameConverter
 import java.awt.Color
@@ -7,6 +8,7 @@ import kotlin.system.measureTimeMillis
 
 // maybe an interface for the methods?
 
+@Tag("benchmark")
 internal class WriteRuntimeTests {
     private val runAmount = 50
     private val size = 6000

--- a/VideoGenerator/library/build.gradle.kts
+++ b/VideoGenerator/library/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
+tasks.test {
+    useJUnitPlatform { excludeTags("benchmark") }
+}
+
 kotlin {
     jvmToolchain(11)
 }

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorBenchmarkTest.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorBenchmarkTest.kt
@@ -2,6 +2,7 @@ import org.bytedeco.ffmpeg.global.avcodec
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.lang.Exception
@@ -10,6 +11,7 @@ import kotlin.math.log10
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
 
+@Tag("benchmark")
 class VideoGeneratorBenchmarkTest {
     private lateinit var videoGenerator: VideoGeneratorImpl
     private val videoPath = "src/resources/testOutput.mkv"

--- a/VideoGenerator/library/src/main/kotlin/VideoGeneratorImpl.kt
+++ b/VideoGenerator/library/src/main/kotlin/VideoGeneratorImpl.kt
@@ -1,4 +1,5 @@
 import org.bytedeco.ffmpeg.global.avcodec
+import org.bytedeco.ffmpeg.global.avutil
 import org.bytedeco.javacv.FFmpegFrameRecorder
 import org.bytedeco.javacv.Frame
 import java.io.ByteArrayInputStream
@@ -17,6 +18,11 @@ class VideoGeneratorImpl(
     var codecId: Int = avcodec.AV_CODEC_ID_FFV1
     var videoFormat: String = "matroska"
     var codecOptions: Map<String, String> = mapOf("" to "")
+
+    init {
+        // turn off verbose ffmpeg output
+        avutil.av_log_set_level(avutil.AV_LOG_QUIET)
+    }
 
     /**
      * Loads a frame from the given byte array.


### PR DESCRIPTION
This enables CI linting (ktlint v1.0.1) and testing (lib1 unit tests, lib2). The gradle caches are cached by the `setup-java` action to speed up repeated runs.

There are some side effects to this PR: 
- FFmpeg logging was turned of in the `DifferenceGenerator` and `VideoGenerator` classes to reduce the cluttering logging output.
- Our various benchmark tests were tagged with the `"benchmark"` tag and that tag was excluded in the `build.gradle.kts` files to reduce the running time of `gradle test`
- The `.editorconfig` was modified to contain the project `root` key. Also, some more explicit settings were added, which does not effectively change the previous implicit settings (AFAIK at least)

The tests currently run in 2 minutes for each library if cached (longer if not cached).

See below to check how it would look in future PRs.

Previous discussion on [my fork's PR](https://github.com/akriese/amos2023ws03-gui-frame-diff/pull/1).