### PR TITLE
feat(gui): include lib2 in gui

### DIFF
--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -9,13 +9,18 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
+// needed if imported as a dependency
+repositories {
+    mavenCentral()
+}
+
 group = "org.example"
 version = "1.0-SNAPSHOT"
 
 dependencies {
     testImplementation(kotlin("test"))
     implementation("org.bytedeco:javacv-platform:1.5.7")
-    testImplementation(project(mapOf("path" to ":VideoGenerator")))
+    implementation(project(path = ":VideoGenerator"))
 }
 
 tasks.test {

--- a/DifferenceGenerator/settings.gradle.kts
+++ b/DifferenceGenerator/settings.gradle.kts
@@ -1,8 +1,5 @@
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-    }
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
 }
 
 include(":VideoGenerator")

--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 
 plugins {
-    kotlin("jvm")
+    kotlin("jvm") version "1.8.0"
     id("org.jetbrains.compose")
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
@@ -28,6 +28,8 @@ dependencies {
     // (in a separate module for demo project and in testMain).
     // With compose.desktop.common you will also lose @Preview functionality
     implementation(compose.desktop.currentOs)
+    implementation("org.bytedeco:javacv-platform:1.5.7")
+    implementation(project(path = ":DifferenceGenerator"))
 }
 
 compose.desktop {

--- a/GUI/settings.gradle.kts
+++ b/GUI/settings.gradle.kts
@@ -11,3 +11,7 @@ pluginManagement {
 }
 
 rootProject.name = "GUI"
+
+include(":DifferenceGenerator", ":VideoGenerator")
+project(":DifferenceGenerator").projectDir = rootProject.projectDir.resolve("../DifferenceGenerator")
+project(":VideoGenerator").projectDir = rootProject.projectDir.resolve("../VideoGenerator/library")

--- a/VideoGenerator/example/settings.gradle.kts
+++ b/VideoGenerator/example/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         google()
         mavenCentral()

--- a/VideoGenerator/library/build.gradle.kts
+++ b/VideoGenerator/library/build.gradle.kts
@@ -7,6 +7,7 @@ group = "org.example"
 version = "1.0-SNAPSHOT"
 
 repositories {
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
This needed some adjustment of the other libraries' gradle settings, as the subprojects' `settings.gradle.kts` are ignored when being used as a dependency. That's why the VideoGenerator is defined as a dependency of the gui, even though there is no direct connection between the gui and lib1. But because lib2 depends on lib1 which is mentioned in lib2's `settings.gradle.kts` (which is not read by the gui), the gui needs to define lib1's project path.