### PR TITLE
determined hyperparameters

### DIFF
--- a/DifferenceGenerator/src/main/kotlin/algorithms/Gotoh.kt
+++ b/DifferenceGenerator/src/main/kotlin/algorithms/Gotoh.kt
@@ -18,8 +18,8 @@ import wrappers.ResettableIterable
  */
 class Gotoh<T>(
     private val metric: MetricInterface<T>,
-    private val gapOpenPenalty: Double,
-    private val gapExtensionPenalty: Double,
+    private val gapOpenPenalty: Double = 0.2,
+    private val gapExtensionPenalty: Double = -0.8,
 ) : AlignmentAlgorithm<T>() {
     private lateinit var score: Array<DoubleArray>
     private lateinit var gapA: Array<DoubleArray>


### PR DESCRIPTION
selected
gapOpenPenalty = 0.2
gapExtensionPenalty= -0.8

![Screenshot_4](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/81f43acb-2d07-4db0-b8e0-3079d813c994)
