### PR TITLE
fix(lib2): Adjust the TestCaseGenerator to the new AlignmentElement

### DIFF
--- a/DifferenceGenerator/src/test/kotlin/TestCaseGenerator.kt
+++ b/DifferenceGenerator/src/test/kotlin/TestCaseGenerator.kt
@@ -1,5 +1,6 @@
 import algorithms.AlignmentElement
 import java.io.File
+import java.io.FilenameFilter
 import kotlin.random.Random
 
 /**
@@ -30,8 +31,9 @@ class TestCaseGenerator(
                         0.3f,
                     AlignmentElement.DELETION to
                         0.05f,
+                    AlignmentElement.MATCH to 0.05f,
                     AlignmentElement.PERFECT to
-                        0.65f,
+                        0.6f,
                 ),
             AlignmentElement.DELETION to
                 mapOf(
@@ -39,8 +41,19 @@ class TestCaseGenerator(
                         0.05f,
                     AlignmentElement.DELETION to
                         0.2f,
+                    AlignmentElement.MATCH to 0.05f,
                     AlignmentElement.PERFECT to
-                        0.75f,
+                        0.7f,
+                ),
+            AlignmentElement.MATCH to
+                mapOf(
+                    AlignmentElement.INSERTION to
+                        0.05f,
+                    AlignmentElement.DELETION to
+                        0.2f,
+                    AlignmentElement.MATCH to 0.1f,
+                    AlignmentElement.PERFECT to
+                        0.65f,
                 ),
             AlignmentElement.PERFECT to
                 mapOf(
@@ -48,8 +61,9 @@ class TestCaseGenerator(
                         0.1f,
                     AlignmentElement.DELETION to
                         0.05f,
+                    AlignmentElement.MATCH to 0.05f,
                     AlignmentElement.PERFECT to
-                        0.85f,
+                        0.8f,
                 ),
         )
 
@@ -62,38 +76,55 @@ class TestCaseGenerator(
         val videoGenerator2 = VideoGeneratorImpl(path2)
 
         var position = 0
-        var result = ArrayList<AlignmentElement>()
+        val result = ArrayList<AlignmentElement>()
 
         var currentElement = AlignmentElement.PERFECT
 
         while (position < baseLength) { // + Random.nextInt(-2, 2)
-            // use transitionProbabilites to determine next element
+            // use transitionProbabilities to determine next element
             // generate random float between 0 and 1
             val randomFloat = Random.nextFloat()
 
-            // get the next element based on the random float
+            // safe the cutoff values for the different alignment elements
+            val currentElementToInsertionThreshold =
+                transitionProbabilities[
+                    currentElement,
+                ]!![
+                    AlignmentElement.INSERTION,
+                ]!!
+            val currentElementToDeletionThreshold =
+                currentElementToInsertionThreshold +
+                    transitionProbabilities[
+                        currentElement,
+                    ]!![
+                        AlignmentElement.DELETION,
+                    ]!!
+
+            val currentElementToMatchThreshold =
+                currentElementToDeletionThreshold +
+                    transitionProbabilities[
+                        currentElement,
+                    ]!![
+                        AlignmentElement.MATCH,
+                    ]!!
+            // determine the next element
             val nextElement =
                 when {
                     randomFloat <
-                        transitionProbabilities[
-                            currentElement,
-                        ]!![
-                            AlignmentElement.INSERTION,
-                        ]!! -> {
+                        currentElementToInsertionThreshold -> {
                         AlignmentElement.INSERTION
                     }
                     randomFloat <
-                        transitionProbabilities[
-                            currentElement,
-                        ]!![
-                            AlignmentElement.INSERTION,
-                        ]!! +
-                        transitionProbabilities[
-                            currentElement,
-                        ]!![
-                            AlignmentElement.DELETION,
-                        ]!! -> {
+                        currentElementToDeletionThreshold -> {
                         AlignmentElement.DELETION
+                    }
+                    randomFloat <
+                        currentElementToMatchThreshold -> {
+                        if (modifiedScreenshotExists(position + 1)) {
+                            AlignmentElement.MATCH
+                        } else {
+                            AlignmentElement.PERFECT
+                        }
                     }
                     else -> {
                         AlignmentElement.PERFECT
@@ -101,10 +132,6 @@ class TestCaseGenerator(
                 }
             // add the next element to the result
             result.add(nextElement)
-
-            // calculate the chance by which to modify the screenshot
-            // such that in average one screenshot is modified
-            val modify = Random.nextFloat() < 1 / baseLength
 
             // add frames to the videos
             when (nextElement) {
@@ -114,16 +141,14 @@ class TestCaseGenerator(
                 AlignmentElement.DELETION -> {
                     videoGenerator1.loadFrame(getByteArray(position + 1, false))
                 }
+                AlignmentElement.MATCH -> {
+                    videoGenerator1.loadFrame(getByteArray(position + 1, false))
+                    videoGenerator2.loadFrame(getByteArray(position + 1, true))
+                }
                 AlignmentElement.PERFECT -> {
                     videoGenerator1.loadFrame(getByteArray(position + 1, false))
-                    videoGenerator2.loadFrame(
-                        getByteArray(
-                            position + 1,
-                            modify,
-                        ),
-                    )
+                    videoGenerator2.loadFrame(getByteArray(position + 1, false))
                 }
-                else -> throw Exception("Invalid alignment element")
             }
 
             position++
@@ -158,5 +183,32 @@ class TestCaseGenerator(
 
         // return the byte array
         return byteArray
+    }
+
+    /**
+     * Checks if a modified screenshot exists for a given index.
+     * @param index The index of the screenshot.
+     * @return True if a modified screenshot exists, false otherwise.
+     */
+    private fun modifiedScreenshotExists(index: Int): Boolean {
+        val pathPrefix = "src/test/resources/"
+        val folder = "screenModifiedOnly/"
+        val paddedIndex = index.toString().padStart(5, '0')
+
+        // create filename filter
+        val fileNameFilter =
+            FilenameFilter { _, name ->
+                name.startsWith("Screenshot$paddedIndex")
+            }
+        // check if a file matching the pattern exists
+        val matchingFiles = File(pathPrefix + folder).listFiles(fileNameFilter)
+
+        if (matchingFiles != null) {
+            if (matchingFiles.size > 1) {
+                throw Exception("There should only be one screenshot with the same index.")
+            }
+            return matchingFiles.isNotEmpty()
+        }
+        return false
     }
 }


### PR DESCRIPTION
The testCaseGenerator now works with all four possible AlignmentElements (Insertion, Deletion, Match and Perfect).
closes #144 