### PR TITLE
doc(general): fix license checks

### DIFF
--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -42,6 +42,7 @@ licenseReport {
     outputDir = "$licensesDir/reports/DifferenceGenerator"
     renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "DifferenceGenerator"))
     filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+    excludeBoms = true
     allowedLicensesFile = File(licensesDir, "allowed-licenses.json")
 }
 

--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -63,6 +63,7 @@ licenseReport {
     outputDir = "$licensesDir/reports/GUI"
     renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "GUI"))
     filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+    excludeBoms = true
     allowedLicensesFile = File(licensesDir, "allowed-licenses.json")
 }
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,11 @@ It is also encouraged to use an on-save formatter as provided by IDEs like Intel
 
 ### License Checking
 
-The project uses a [gradle plugin](https://github.com/jk1/Gradle-License-Report) to generate dependency license reports.
-The reports are all saved in the `./licenses/reports/<SubprojectName>` directories.
-Currently, we are allowing the licenses `MIT` and `Apache 2.0`. This information can be changed
-in `./licenses/allowed-licenses.json`.
-
 For `lib1` (analogous for `lib2` ("VideoGenerator") and the `gui` ("GUI"))
 - Run a task that fails if dependencies with non-allowed licenses are found.
 - `cd ./VideoGenerator && ./gradlew checkLicense`
 - Generate a license report in html
 - `cd ./VideoGenerator && ./gradlew generateLicenseReport`
+
+For more information, read the [license README](./licenses/README.md).
+

--- a/VideoGenerator/build.gradle.kts
+++ b/VideoGenerator/build.gradle.kts
@@ -41,6 +41,7 @@ licenseReport {
     outputDir = "$licensesDir/reports/VideoGenerator"
     renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "VideoGenerator"))
     filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+    excludeBoms = true
     allowedLicensesFile = File(licensesDir, "allowed-licenses.json")
 }
 /*

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,11 @@
+# Generating license reports for our dependencies
+
+The project uses a [gradle plugin](https://github.com/jk1/Gradle-License-Report) to generate dependency license reports.
+
+The reports are all saved in the `./licenses/reports/<SubprojectName>` directories.
+Currently, we are allowing the licenses `MIT` and `Apache 2.0`. Furthermore, the plugin
+has difficulties (see this [issue](https://github.com/jk1/Gradle-License-Report/issues/272))
+recognizing licenses for jetbrains packages (`compose`, `skiko`, `kotlinx`),
+which are all under the `Apache 2.0` license. Thus, we can safely white-flag them.
+
+This information can be changed in `./licenses/allowed-licenses.json`.

--- a/licenses/allowed-licenses.json
+++ b/licenses/allowed-licenses.json
@@ -5,6 +5,21 @@
     },
     {
       "moduleLicense": "MIT License"
+    },
+    {
+      "moduleLicense": "Eclipse Public License - v 2.0"
+    },
+    {
+      "moduleLicense": null,
+      "moduleName": "org.jetbrains.kotlinx:.*"
+    },
+    {
+      "moduleLicense": null,
+      "moduleName": "org.jetbrains.skiko:.*"
+    },
+    {
+      "moduleLicense": null,
+      "moduleName": "org.jetbrains.compose..*"
     }
   ]
 }


### PR DESCRIPTION
This is done by including certain packages in the
allowed licenses file. The plugin has trouble with resolving license files for the mentioned packages, which is mentioned in the new license README with a link to the issue on GitHub.
I checked the mentioned packages (all jetbrains') and they all offer the Apache 2.0 license, so this should be fine.