### PR TITLE
Add info icons

### DIFF
--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -2,12 +2,13 @@ import com.github.jk1.license.filter.DependencyFilter
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.InventoryHtmlReportRenderer
 import com.github.jk1.license.render.ReportRenderer
+import org.jetbrains.compose.compose
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.8.0"
-    id("org.jetbrains.compose") version "1.5.11"
+    id("org.jetbrains.compose")
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
 

--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -2,19 +2,19 @@ import com.github.jk1.license.filter.DependencyFilter
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.InventoryHtmlReportRenderer
 import com.github.jk1.license.render.ReportRenderer
-import org.jetbrains.compose.compose
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-
 plugins {
     kotlin("jvm") version "1.8.0"
-    id("org.jetbrains.compose")
+    id("org.jetbrains.compose") version "1.5.11"
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
 group = "com.example"
-version = "1.0.0" // WARNING: If this value is updated, it should be updated in the AppConfig class too
+
+// WARNING: If this value is updated, it should be updated in the AppConfig class too
+version = "1.0.0"
 
 repositories {
     google()
@@ -28,6 +28,7 @@ dependencies {
     // (in a separate module for demo project and in testMain).
     // With compose.desktop.common you will also lose @Preview functionality
     implementation(compose.desktop.currentOs)
+    implementation(compose.material3)
     implementation("org.bytedeco:javacv-platform:1.5.7")
     implementation(project(path = ":DifferenceGenerator"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.3")
@@ -46,15 +47,11 @@ compose.desktop {
     }
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
-}
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 
 tasks.register<Jar>("createRunnableJar") {
     from(sourceSets.main.get().output)
-    manifest {
-        attributes["Main-Class"] = "MainKt"
-    }
+    manifest { attributes["Main-Class"] = "MainKt" }
     archiveFileName.set("GUI-Runnable.jar")
     destinationDirectory.set(file("$buildDir/libs"))
 }

--- a/GUI/src/main/kotlin/ui/components/CustomSlider.kt
+++ b/GUI/src/main/kotlin/ui/components/CustomSlider.kt
@@ -27,14 +27,21 @@ fun RowScope.CustomSlider(
     minValue: Double,
     maxValue: Double,
     onChange: (Double) -> Unit,
+    tooltipText: String? = null,
 ) {
     // the value of the slider
     var sliderValue = remember { mutableStateOf(default) }
     var textValue = remember { mutableStateOf(default.toString()) }
+
     // Column contains the slider construct
-    Column(modifier = Modifier.weight(1f).padding(8.dp).fillMaxHeight(1f)) {
+    Column(modifier = Modifier.weight(1f).padding(8.dp).fillMaxHeight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
         // title
-        AutoSizeText(text = title, modifier = Modifier.weight(0.5f).padding(8.dp).fillMaxHeight(1f).align(Alignment.CenterHorizontally))
+        if (tooltipText != null) {
+            TextTitleWithInfo(Modifier.weight(0.5f), title, tooltipText)
+        } else {
+            AutoSizeText(modifier = Modifier.weight(0.5f).padding(8.dp), text = title)
+        }
+
         // slider
         Row(modifier = Modifier.weight(0.2f)) {
             // min value

--- a/GUI/src/main/kotlin/ui/components/CustomSlider.kt
+++ b/GUI/src/main/kotlin/ui/components/CustomSlider.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import java.awt.SystemColor.text
 
 /**
  * Title is a composable that displays a title.
@@ -37,7 +36,7 @@ fun RowScope.CustomSlider(
     Column(modifier = Modifier.weight(1f).padding(8.dp).fillMaxHeight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
         // title
         if (tooltipText != null) {
-            TextTitleWithInfo(Modifier.weight(0.5f), title, tooltipText)
+            TitleWithInfo(Modifier.weight(0.5f), title, tooltipText)
         } else {
             AutoSizeText(modifier = Modifier.weight(0.5f).padding(8.dp), text = title)
         }

--- a/GUI/src/main/kotlin/ui/components/FileSelectorButton.kt
+++ b/GUI/src/main/kotlin/ui/components/FileSelectorButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.painterResource
@@ -23,6 +24,7 @@ fun RowScope.FileSelectorButton(
     buttonText: String,
     buttonPath: String,
     onUpdateResult: (String) -> Unit,
+    tooltipText: String? = null,
 ) {
     Button(
         modifier = Modifier.weight(1f).padding(8.dp).fillMaxHeight(1f),
@@ -38,14 +40,17 @@ fun RowScope.FileSelectorButton(
         },
     ) {
         // column to display the button text and the selected file path
-        Column(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
             // row to display the upload icon
             Row(modifier = Modifier.weight(0.75f)) {
                 Image(
                     painter = painterResource("upload.svg"),
                     contentDescription = "Upload",
-                    modifier = Modifier.fillMaxSize().alpha(0.8f),
+                    modifier = Modifier.alpha(0.8f),
                 )
+                if (tooltipText != null) {
+                    InfoIconWithHover(tooltipText)
+                }
             }
             // row to display the button text
             Row(modifier = Modifier.weight(0.15f)) { AutoSizeText(text = buttonText) }

--- a/GUI/src/main/kotlin/ui/components/InfoIconWithHover.kt
+++ b/GUI/src/main/kotlin/ui/components/InfoIconWithHover.kt
@@ -1,0 +1,47 @@
+package ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun InfoIconWithHover(text: String) {
+    var isHovered by remember { mutableStateOf(false) }
+
+    Box(
+        modifier =
+            Modifier
+                .onPointerEvent(PointerEventType.Enter) { isHovered = true }
+                .onPointerEvent(PointerEventType.Exit) { isHovered = false },
+    ) {
+        Icon(
+            imageVector = Icons.Default.Info,
+            contentDescription = null,
+            tint =
+                if (isHovered) {
+                    MaterialTheme.colors.primary
+                } else {
+                    MaterialTheme.colors.onBackground.copy(
+                        alpha = LocalContentAlpha.current,
+                    )
+                },
+            modifier = Modifier.size(24.dp),
+        )
+
+        // Use Popup to show the tooltip
+        if (isHovered) {
+            Tooltip(text = text)
+        }
+    }
+}

--- a/GUI/src/main/kotlin/ui/components/TextTitle.kt
+++ b/GUI/src/main/kotlin/ui/components/TextTitle.kt
@@ -1,8 +1,6 @@
 package ui.components
 
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -19,4 +17,27 @@ fun RowScope.textTitle(text: String) {
         text = text,
         modifier = Modifier.weight(1f).fillMaxSize().padding(20.dp),
     )
+}
+
+/**
+ * A Composable function that creates a title text with a tooltip icon next to it.
+ * @param modifier [Modifier] containing formatting options from the parent.
+ * @param text [String] containing the text to be displayed.
+ * @param tooltipText [String] containing the info text for the tooltip.
+ * @return [Unit]
+ */
+@Composable
+fun TextTitleWithInfo(
+    modifier: Modifier,
+    text: String,
+    tooltipText: String,
+) {
+    Row(modifier = modifier.padding(8.dp)) {
+        AutoSizeText(
+            text = text,
+            modifier = Modifier.padding(0.dp),
+        )
+
+        InfoIconWithHover(tooltipText)
+    }
 }

--- a/GUI/src/main/kotlin/ui/components/TextTitle.kt
+++ b/GUI/src/main/kotlin/ui/components/TextTitle.kt
@@ -18,26 +18,3 @@ fun RowScope.textTitle(text: String) {
         modifier = Modifier.weight(1f).fillMaxSize().padding(20.dp),
     )
 }
-
-/**
- * A Composable function that creates a title text with a tooltip icon next to it.
- * @param modifier [Modifier] containing formatting options from the parent.
- * @param text [String] containing the text to be displayed.
- * @param tooltipText [String] containing the info text for the tooltip.
- * @return [Unit]
- */
-@Composable
-fun TextTitleWithInfo(
-    modifier: Modifier,
-    text: String,
-    tooltipText: String,
-) {
-    Row(modifier = modifier.padding(8.dp)) {
-        AutoSizeText(
-            text = text,
-            modifier = Modifier.padding(0.dp),
-        )
-
-        InfoIconWithHover(tooltipText)
-    }
-}

--- a/GUI/src/main/kotlin/ui/components/TitleWithInfo.kt
+++ b/GUI/src/main/kotlin/ui/components/TitleWithInfo.kt
@@ -1,0 +1,30 @@
+package ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * A Composable function that creates a title text with a tooltip icon next to it.
+ * @param modifier [Modifier] containing formatting options from the parent.
+ * @param text [String] containing the text to be displayed.
+ * @param tooltipText [String] containing the info text for the tooltip.
+ * @return [Unit]
+ */
+@Composable
+fun TitleWithInfo(
+    modifier: Modifier,
+    text: String,
+    tooltipText: String,
+) {
+    Row(modifier = modifier.padding(8.dp)) {
+        AutoSizeText(
+            text = text,
+            modifier = Modifier.padding(0.dp),
+        )
+
+        InfoIconWithHover(tooltipText)
+    }
+}

--- a/GUI/src/main/kotlin/ui/components/TitleWithInfo.kt
+++ b/GUI/src/main/kotlin/ui/components/TitleWithInfo.kt
@@ -19,10 +19,10 @@ fun TitleWithInfo(
     text: String,
     tooltipText: String,
 ) {
-    Row(modifier = modifier.padding(8.dp)) {
+    Row(modifier = modifier.padding(4.dp)) {
         AutoSizeText(
             text = text,
-            modifier = Modifier.padding(0.dp),
+            modifier = Modifier.padding(2.dp),
         )
 
         InfoIconWithHover(tooltipText)

--- a/GUI/src/main/kotlin/ui/components/Tooltip.kt
+++ b/GUI/src/main/kotlin/ui/components/Tooltip.kt
@@ -1,0 +1,35 @@
+package ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+
+@Composable
+fun Tooltip(text: String) {
+    val cornerSize = 16.dp
+    Popup(
+        alignment = Alignment.BottomEnd,
+        offset = IntOffset(-24, 0),
+    ) {
+        // Draw a rectangle shape with rounded corners inside the popup
+        Box(
+            Modifier
+                .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
+        ) {
+            Text(
+                text = text,
+                modifier = Modifier.padding(8.dp),
+                color = Color.White,
+            )
+        }
+    }
+}

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -63,6 +63,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
             FileSelectorButton(
                 buttonText = "Upload Mask",
                 buttonPath = state.value.maskPath,
+                tooltipText = textForMask,
                 onUpdateResult = { selectedFilePath ->
                     state.value = state.value.copy(maskPath = selectedFilePath)
                 },

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -1,7 +1,5 @@
 package ui.screens
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -23,11 +21,11 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import models.AppState
 import ui.components.CustomSlider
 import ui.components.FileSelectorButton
 import ui.components.textTitle
-import androidx.compose.ui.window.Popup
 
 /**
  * SettingsScreen is the screen where the user can change the settings of the app.
@@ -141,26 +139,38 @@ fun RowScope.SaveButton(
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun InfoIconWithHover(text: String, modifier: Modifier = Modifier) {
+fun InfoIconWithHover(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
     var isHovered by remember { mutableStateOf(false) }
 
     Box(
-        modifier = Modifier
-            .onPointerEvent(PointerEventType.Enter) {
-                isHovered = true
-            }
-            .onPointerEvent(PointerEventType.Exit) {
-                isHovered = false
-            }
-            .then(modifier),
+        modifier =
+            Modifier
+                .onPointerEvent(PointerEventType.Enter) {
+                    isHovered = true
+                }
+                .onPointerEvent(PointerEventType.Exit) {
+                    isHovered = false
+                }
+                .then(modifier),
         contentAlignment = Alignment.TopEnd,
     ) {
         Icon(
             imageVector = Icons.Default.Info,
             contentDescription = null,
-            tint = MaterialTheme.colors.primary,
-            modifier = Modifier
-                .size(24.dp),
+            tint =
+                if (isHovered) {
+                    MaterialTheme.colors.primary
+                } else {
+                    MaterialTheme.colors.onBackground.copy(
+                        alpha = LocalContentAlpha.current,
+                    )
+                },
+            modifier =
+                Modifier
+                    .size(24.dp),
         )
 
         // Use Popup to show the tooltip
@@ -172,21 +182,21 @@ fun InfoIconWithHover(text: String, modifier: Modifier = Modifier) {
 
 @Composable
 fun Tooltip(text: String) {
-        val cornerSize = 16.dp
-        Popup(
-            alignment = Alignment.CenterEnd,
-            offset = IntOffset(-24,0)
+    val cornerSize = 16.dp
+    Popup(
+        alignment = Alignment.CenterEnd,
+        offset = IntOffset(-24, 0),
+    ) {
+        // Draw a rectangle shape with rounded corners inside the popup
+        Box(
+            Modifier
+                .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
         ) {
-            // Draw a rectangle shape with rounded corners inside the popup
-            Box(
-                Modifier
-                    .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
-            ) {
-                Text(
-                    text = text,
-                    modifier = Modifier.padding(8.dp),
-                    color = Color.White
-                )
-            }
+            Text(
+                text = text,
+                modifier = Modifier.padding(8.dp),
+                color = Color.White,
+            )
         }
+    }
 }

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -36,10 +36,15 @@ import ui.components.textTitle
 @Composable
 fun SettingsScreen(state: MutableState<AppState>) {
     val oldState = remember { mutableStateOf(state.value.copy()) }
-    val textForHyper = "The hyperparameter are settings to adjust the distinction between added and deleted frames and a pixel difference within a frame."
+    val textForHyper =
+        "The hyperparameter are settings to adjust the distinction between added and deleted frames and" +
+            " a pixel difference within a frame."
     val textForGapOpen = "add here explanation for gap open"
     val textForGapExtended = "add here explanation for gap extended"
-    val textForMask = "Upload a png with white and black rectangles.\nEverything that is within white rectangles in video will be considered in the video difference computation and everything that is within black rectangles will be not considered in the video difference computation."
+    val textForMask =
+        "Upload a png with white and black rectangles" +
+            ".\nEverything that is within white rectangles in video will be considered in the video difference computation " +
+            "and everything that is within black rectangles will be not considered in the video difference computation."
 
     // Contains the whole Screen
     Column(modifier = Modifier.fillMaxSize()) {
@@ -200,7 +205,7 @@ fun Tooltip(text: String) {
                 Text(
                     text = text,
                     modifier = Modifier,
-                    color = Color.White
+                    color = Color.White,
                 )
             }
         }

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -1,26 +1,20 @@
 package ui.screens
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.PlainTooltipBox
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
 import models.AppState
 import ui.components.CustomSlider
 import ui.components.FileSelectorButton
@@ -32,7 +26,6 @@ import ui.components.textTitle
  * @param state the state of the app
  * @param oldState the previous state of the app
  */
-
 @Composable
 fun SettingsScreen(state: MutableState<AppState>) {
     val oldState = remember { mutableStateOf(state.value.copy()) }
@@ -49,9 +42,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
     // Contains the whole Screen
     Column(modifier = Modifier.fillMaxSize()) {
         // Title
-        Row(modifier = Modifier.weight(0.2f)) {
-            textTitle("Settings")
-        }
+        Row(modifier = Modifier.weight(0.2f)) { textTitle("Settings") }
         Row(modifier = Modifier.weight(0.15f)) {
             textTitle("Hyperparameters")
             InfoIconWithHover(textForHyper)
@@ -106,12 +97,8 @@ fun RowScope.BackButton(
     oldState: MutableState<AppState>,
 ) {
     Button(
-        // fills all available space
         modifier = Modifier.weight(0.1f).padding(8.dp).fillMaxSize(1f),
-        onClick = {
-            state.value =
-                oldState.value.copy(screen = Screen.SelectVideoScreen)
-        },
+        onClick = { state.value = oldState.value.copy(screen = Screen.SelectVideoScreen) },
     ) {
         Image(
             painter = painterResource("back-arrow.svg"),
@@ -131,8 +118,7 @@ fun RowScope.SaveButton(
         modifier = Modifier.weight(0.1f).padding(8.dp).fillMaxSize(1f),
         onClick = {
             oldState.value = state.value
-            state.value =
-                oldState.value.copy(screen = Screen.SelectVideoScreen)
+            state.value = oldState.value.copy(screen = Screen.SelectVideoScreen)
         },
     ) {
         Image(
@@ -143,71 +129,23 @@ fun RowScope.SaveButton(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InfoIconWithHover(text: String) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isHovered by interactionSource.collectIsHoveredAsState()
-
-    // Remember the current hover state to use in DisposableEffect
-    var currentIsHovered by remember { mutableStateOf(isHovered) }
-
-    DisposableEffect(currentIsHovered) {
-        onDispose {
-            // Close the tooltip when the composable is disposed
-            currentIsHovered = false
-        }
-    }
-
-    Box(
-        modifier =
-            Modifier
-                .size(40.dp)
-                .hoverable(
-                    interactionSource = interactionSource,
-                ),
-        contentAlignment = Alignment.Center,
+    PlainTooltipBox(
+        tooltip = {
+            Text(
+                text = text,
+                modifier = Modifier,
+                color = Color.White,
+            )
+        },
     ) {
-        // Info icon
         Icon(
             imageVector = Icons.Default.Info,
             contentDescription = null,
-            tint =
-                if (isHovered) {
-                    MaterialTheme.colors.primary
-                } else {
-                    MaterialTheme.colors.onBackground.copy(
-                        alpha = LocalContentAlpha.current,
-                    )
-                },
-            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp).tooltipAnchor(),
         )
-
-        // Tooltip
-        if (isHovered) {
-            // Set the current hover state to true
-            currentIsHovered = true
-            Tooltip(text = text)
-        }
-    }
-}
-
-@Composable
-fun Tooltip(text: String) {
-    Box {
-        val cornerSize = 16.dp
-
-        Popup(alignment = Alignment.CenterEnd) {
-            // Draw a rectangle shape with rounded corners inside the popup
-            Box(
-                Modifier
-                    .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
-            ) {
-                Text(
-                    text = text,
-                    modifier = Modifier,
-                    color = Color.White,
-                )
-            }
-        }
     }
 }

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -1,13 +1,26 @@
 package ui.screens
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Button
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.*
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import models.AppState
 import ui.components.CustomSlider
 import ui.components.FileSelectorButton
@@ -23,16 +36,25 @@ import ui.components.textTitle
 @Composable
 fun SettingsScreen(state: MutableState<AppState>) {
     val oldState = remember { mutableStateOf(state.value.copy()) }
+    val textForHyper = "The hyperparameter are settings to adjust the distinction between added and deleted frames and a pixel difference within a frame."
+    val textForGapOpen = "add here explanation for gap open"
+    val textForGapExtended = "add here explanation for gap extended"
+    val textForMask = "Upload a png with white and black rectangles.\nEverything that is within white rectangles in video will be considered in the video difference computation and everything that is within black rectangles will be not considered in the video difference computation."
+
     // Contains the whole Screen
     Column(modifier = Modifier.fillMaxSize()) {
         // Title
         Row(modifier = Modifier.weight(0.2f)) {
             textTitle("Settings")
         }
+        Row(modifier = Modifier.weight(0.15f)) {
+            textTitle("Hyperparameters")
+            InfoIconWithHover(textForHyper)
+        }
         // gap open penalty
-        Row(modifier = Modifier.weight(0.2f)) {
+        Row(modifier = Modifier.weight(0.125f)) {
             CustomSlider(
-                title = " gapOpenPenalty",
+                title = "gapOpenPenalty",
                 default = state.value.gapOpenPenalty,
                 minValue = -1.0,
                 maxValue = 0.5,
@@ -40,9 +62,10 @@ fun SettingsScreen(state: MutableState<AppState>) {
                     state.value = state.value.copy(gapOpenPenalty = it)
                 },
             )
+            InfoIconWithHover(textForGapOpen)
         }
         // gap extend penalty
-        Row(modifier = Modifier.weight(0.2f)) {
+        Row(modifier = Modifier.weight(0.125f)) {
             CustomSlider(
                 title = "gapExtensionPenalty",
                 default = state.value.gapExtendPenalty,
@@ -50,6 +73,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
                 maxValue = 0.5,
                 onChange = { state.value = state.value.copy(gapExtendPenalty = it) },
             )
+            InfoIconWithHover(textForGapExtended)
         }
         // mask
         Row(modifier = Modifier.weight(0.2f)) {
@@ -60,6 +84,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
                     state.value = state.value.copy(maskPath = selectedFilePath)
                 },
             )
+            InfoIconWithHover(textForMask)
         }
         Row(modifier = Modifier.weight(0.2f)) {
             // back
@@ -110,5 +135,74 @@ fun RowScope.SaveButton(
             contentDescription = "save",
             modifier = Modifier.fillMaxSize().alpha(0.8f).padding(4.dp),
         )
+    }
+}
+
+@Composable
+fun InfoIconWithHover(text: String) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    // Remember the current hover state to use in DisposableEffect
+    var currentIsHovered by remember { mutableStateOf(isHovered) }
+
+    DisposableEffect(currentIsHovered) {
+        onDispose {
+            // Close the tooltip when the composable is disposed
+            currentIsHovered = false
+        }
+    }
+
+    Box(
+        modifier =
+            Modifier
+                .size(40.dp)
+                .hoverable(
+                    interactionSource = interactionSource,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Info icon
+        Icon(
+            imageVector = Icons.Default.Info,
+            contentDescription = null,
+            tint =
+                if (isHovered) {
+                    MaterialTheme.colors.primary
+                } else {
+                    MaterialTheme.colors.onBackground.copy(
+                        alpha = LocalContentAlpha.current,
+                    )
+                },
+            modifier = Modifier.size(24.dp),
+        )
+
+        // Tooltip
+        if (isHovered) {
+            // Set the current hover state to true
+            currentIsHovered = true
+            Tooltip(text = text)
+        }
+    }
+}
+
+@Composable
+fun Tooltip(text: String) {
+    Box {
+        val cornerSize = 16.dp
+
+        Popup(alignment = Alignment.CenterEnd) {
+            // Draw a rectangle shape with rounded corners inside the popup
+            Box(
+                Modifier
+                    .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
+            ) {
+                Text(
+                    text = text,
+                    modifier = Modifier,
+                    color = Color.White
+                )
+            }
+        }
     }
 }

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -22,10 +22,17 @@ import ui.components.*
 fun SettingsScreen(state: MutableState<AppState>) {
     val oldState = remember { mutableStateOf(state.value.copy()) }
     val textForHyper =
-        "Settings to adjust the distinction between added/deleted frames and" +
-            " pixel differences within frames."
-    val textForGapOpen = "explanation for gap open"
-    val textForGapExtended = "explanation for gap extended"
+        "Settings to adjust behavior of the Gotoh alignment algorithm,\n" +
+            "which determines the matches between frames from both input videos."
+    val textForGapOpen =
+        "Penalty score for starting a new gap (insertion/deletion) in the alignment.\n" +
+            "Decreasing this value will favor fewer, larger gaps in the alignment."
+    val textForGapExtended =
+        "Penalty score for extending an existing gap (insertion/deletion) in the alignment.\n" +
+            "Increasing this value will favor longer gaps in the alignment.\n" +
+            "The gapOpenPenalty should be smaller than the gapExtensionPenalty.\n" +
+            "If both parameters are equal, the algorithm will behave like the Needleman-Wunsch algorithm,\n" +
+            "meaning that new gaps are as likely as extending existing gaps."
     val textForMask =
         "Upload a png with white and black rectangles" +
             ".\nThe area marked with white rectangles will be included in the video difference computation " +

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -35,7 +35,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         // Title
         Row(modifier = Modifier.weight(0.2f)) { textTitle("Settings") }
-        TextTitleWithInfo(Modifier.weight(0.15f), "Hyperparameters", textForHyper)
+        TitleWithInfo(Modifier.weight(0.15f), "Hyperparameters", textForHyper)
         // gap open penalty
         Row(modifier = Modifier.weight(0.2f)) {
             CustomSlider(

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -1,24 +1,33 @@
 package ui.screens
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material3.*
-import androidx.compose.material3.Icon
-import androidx.compose.material3.PlainTooltipBox
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import models.AppState
 import ui.components.CustomSlider
 import ui.components.FileSelectorButton
 import ui.components.textTitle
+import androidx.compose.ui.window.Popup
 
 /**
  * SettingsScreen is the screen where the user can change the settings of the app.
@@ -30,14 +39,14 @@ import ui.components.textTitle
 fun SettingsScreen(state: MutableState<AppState>) {
     val oldState = remember { mutableStateOf(state.value.copy()) }
     val textForHyper =
-        "The hyperparameter are settings to adjust the distinction between added and deleted frames and" +
-            " a pixel difference within a frame."
-    val textForGapOpen = "add here explanation for gap open"
-    val textForGapExtended = "add here explanation for gap extended"
+        "Settings to adjust the distinction between added/deleted frames and" +
+            " pixel differences within frames."
+    val textForGapOpen = "explanation for gap open"
+    val textForGapExtended = "explanation for gap extended"
     val textForMask =
         "Upload a png with white and black rectangles" +
-            ".\nEverything that is within white rectangles in video will be considered in the video difference computation " +
-            "and everything that is within black rectangles will be not considered in the video difference computation."
+            ".\nThe area marked with white rectangles will be included in the video difference computation " +
+            "and the area with black rectangles will not be included in the computation."
 
     // Contains the whole Screen
     Column(modifier = Modifier.fillMaxSize()) {
@@ -97,6 +106,7 @@ fun RowScope.BackButton(
     oldState: MutableState<AppState>,
 ) {
     Button(
+        // fills all available space
         modifier = Modifier.weight(0.1f).padding(8.dp).fillMaxSize(1f),
         onClick = { state.value = oldState.value.copy(screen = Screen.SelectVideoScreen) },
     ) {
@@ -129,23 +139,54 @@ fun RowScope.SaveButton(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun InfoIconWithHover(text: String) {
-    PlainTooltipBox(
-        tooltip = {
-            Text(
-                text = text,
-                modifier = Modifier,
-                color = Color.White,
-            )
-        },
+fun InfoIconWithHover(text: String, modifier: Modifier = Modifier) {
+    var isHovered by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .onPointerEvent(PointerEventType.Enter) {
+                isHovered = true
+            }
+            .onPointerEvent(PointerEventType.Exit) {
+                isHovered = false
+            }
+            .then(modifier),
+        contentAlignment = Alignment.TopEnd,
     ) {
         Icon(
             imageVector = Icons.Default.Info,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(24.dp).tooltipAnchor(),
+            tint = MaterialTheme.colors.primary,
+            modifier = Modifier
+                .size(24.dp),
         )
+
+        // Use Popup to show the tooltip
+        if (isHovered) {
+            Tooltip(text = text)
+        }
     }
+}
+
+@Composable
+fun Tooltip(text: String) {
+        val cornerSize = 16.dp
+        Popup(
+            alignment = Alignment.CenterEnd,
+            offset = IntOffset(-24,0)
+        ) {
+            // Draw a rectangle shape with rounded corners inside the popup
+            Box(
+                Modifier
+                    .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
+            ) {
+                Text(
+                    text = text,
+                    modifier = Modifier.padding(8.dp),
+                    color = Color.White
+                )
+            }
+        }
 }

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -34,10 +34,9 @@ fun SettingsScreen(state: MutableState<AppState>) {
             "If both parameters are equal, the algorithm will behave like the Needleman-Wunsch algorithm,\n" +
             "meaning that new gaps are as likely as extending existing gaps."
     val textForMask =
-        "Upload a png with white and black rectangles" +
-            ".\nThe area marked with white rectangles will be included in the video difference computation " +
-            "and the area with black rectangles will not be included in the computation."
-
+        "Upload a png with a clear background and colored areas.\n" +
+            "The transparent areas will be included in the video difference computation \n" +
+            "while the opaque areas will be excluded."
     // Contains the whole Screen
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         // Title

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -55,7 +55,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
             InfoIconWithHover(textForHyper)
         }
         // gap open penalty
-        Row(modifier = Modifier.weight(0.125f)) {
+        Row(modifier = Modifier.weight(0.2f)) {
             CustomSlider(
                 title = "gapOpenPenalty",
                 default = state.value.gapOpenPenalty,
@@ -68,7 +68,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
             InfoIconWithHover(textForGapOpen)
         }
         // gap extend penalty
-        Row(modifier = Modifier.weight(0.125f)) {
+        Row(modifier = Modifier.weight(0.2f)) {
             CustomSlider(
                 title = "gapExtensionPenalty",
                 default = state.value.gapExtendPenalty,
@@ -79,7 +79,7 @@ fun SettingsScreen(state: MutableState<AppState>) {
             InfoIconWithHover(textForGapExtended)
         }
         // mask
-        Row(modifier = Modifier.weight(0.2f)) {
+        Row(modifier = Modifier.weight(0.175f)) {
             FileSelectorButton(
                 buttonText = "Upload Mask",
                 buttonPath = state.value.maskPath,
@@ -139,10 +139,7 @@ fun RowScope.SaveButton(
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun InfoIconWithHover(
-    text: String,
-    modifier: Modifier = Modifier,
-) {
+fun InfoIconWithHover(text: String) {
     var isHovered by remember { mutableStateOf(false) }
 
     Box(
@@ -153,9 +150,7 @@ fun InfoIconWithHover(
                 }
                 .onPointerEvent(PointerEventType.Exit) {
                     isHovered = false
-                }
-                .then(modifier),
-        contentAlignment = Alignment.TopEnd,
+                },
     ) {
         Icon(
             imageVector = Icons.Default.Info,
@@ -184,7 +179,7 @@ fun InfoIconWithHover(
 fun Tooltip(text: String) {
     val cornerSize = 16.dp
     Popup(
-        alignment = Alignment.CenterEnd,
+        alignment = Alignment.BottomEnd,
         offset = IntOffset(-24, 0),
     ) {
         // Draw a rectangle shape with rounded corners inside the popup

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -1,31 +1,16 @@
 package ui.screens
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.*
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
 import models.AppState
-import ui.components.CustomSlider
-import ui.components.FileSelectorButton
-import ui.components.textTitle
+import ui.components.*
 
 /**
  * SettingsScreen is the screen where the user can change the settings of the app.
@@ -47,13 +32,10 @@ fun SettingsScreen(state: MutableState<AppState>) {
             "and the area with black rectangles will not be included in the computation."
 
     // Contains the whole Screen
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         // Title
         Row(modifier = Modifier.weight(0.2f)) { textTitle("Settings") }
-        Row(modifier = Modifier.weight(0.15f)) {
-            textTitle("Hyperparameters")
-            InfoIconWithHover(textForHyper)
-        }
+        TextTitleWithInfo(Modifier.weight(0.15f), "Hyperparameters", textForHyper)
         // gap open penalty
         Row(modifier = Modifier.weight(0.2f)) {
             CustomSlider(
@@ -61,11 +43,9 @@ fun SettingsScreen(state: MutableState<AppState>) {
                 default = state.value.gapOpenPenalty,
                 minValue = -1.0,
                 maxValue = 0.5,
-                onChange = {
-                    state.value = state.value.copy(gapOpenPenalty = it)
-                },
+                tooltipText = textForGapOpen,
+                onChange = { state.value = state.value.copy(gapOpenPenalty = it) },
             )
-            InfoIconWithHover(textForGapOpen)
         }
         // gap extend penalty
         Row(modifier = Modifier.weight(0.2f)) {
@@ -74,9 +54,9 @@ fun SettingsScreen(state: MutableState<AppState>) {
                 default = state.value.gapExtendPenalty,
                 minValue = -1.0,
                 maxValue = 0.5,
+                tooltipText = textForGapExtended,
                 onChange = { state.value = state.value.copy(gapExtendPenalty = it) },
             )
-            InfoIconWithHover(textForGapExtended)
         }
         // mask
         Row(modifier = Modifier.weight(0.175f)) {
@@ -87,7 +67,6 @@ fun SettingsScreen(state: MutableState<AppState>) {
                     state.value = state.value.copy(maskPath = selectedFilePath)
                 },
             )
-            InfoIconWithHover(textForMask)
         }
         Row(modifier = Modifier.weight(0.2f)) {
             // back
@@ -134,64 +113,5 @@ fun RowScope.SaveButton(
             contentDescription = "save",
             modifier = Modifier.fillMaxSize().alpha(0.8f).padding(4.dp),
         )
-    }
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-fun InfoIconWithHover(text: String) {
-    var isHovered by remember { mutableStateOf(false) }
-
-    Box(
-        modifier =
-            Modifier
-                .onPointerEvent(PointerEventType.Enter) {
-                    isHovered = true
-                }
-                .onPointerEvent(PointerEventType.Exit) {
-                    isHovered = false
-                },
-    ) {
-        Icon(
-            imageVector = Icons.Default.Info,
-            contentDescription = null,
-            tint =
-                if (isHovered) {
-                    MaterialTheme.colors.primary
-                } else {
-                    MaterialTheme.colors.onBackground.copy(
-                        alpha = LocalContentAlpha.current,
-                    )
-                },
-            modifier =
-                Modifier
-                    .size(24.dp),
-        )
-
-        // Use Popup to show the tooltip
-        if (isHovered) {
-            Tooltip(text = text)
-        }
-    }
-}
-
-@Composable
-fun Tooltip(text: String) {
-    val cornerSize = 16.dp
-    Popup(
-        alignment = Alignment.BottomEnd,
-        offset = IntOffset(-24, 0),
-    ) {
-        // Draw a rectangle shape with rounded corners inside the popup
-        Box(
-            Modifier
-                .background(Color.DarkGray, RoundedCornerShape(cornerSize)),
-        ) {
-            Text(
-                text = text,
-                modifier = Modifier.padding(8.dp),
-                color = Color.White,
-            )
-        }
     }
 }


### PR DESCRIPTION
Closes #172 

This PR adds info icons in the settings screen. When hovering the icons, a corresponding text is displayed.