### PR TITLE
feat(gui): display version number in window title

### DIFF
--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.0-SNAPSHOT"
+version = "1.0.0" // WARNING: If this value is updated, it should be updated in the AppConfig class too
 
 repositories {
     google()

--- a/GUI/src/main/kotlin/Main.kt
+++ b/GUI/src/main/kotlin/Main.kt
@@ -17,7 +17,7 @@ import ui.themes.wrapTheming
 fun main(): Unit =
     application {
         Window(
-            title = "amos2023ws03-gui-frame-diff",
+            title = "GUI Frame Diff v${AppConfig.VERSION}",
             onCloseRequest = ::exitApplication,
             state = WindowState(width = 1800.dp, height = 1000.dp),
         ) {
@@ -43,4 +43,8 @@ fun App() {
         is Screen.SettingsScreen -> SettingsScreen(globalState)
         else -> throw Exception("Screen not implemented")
     }
+}
+
+object AppConfig {
+    const val VERSION = "1.0.0" // has to be updated manually, when the version in gradle is updated
 }


### PR DESCRIPTION
I tried using a plugin (https://github.com/gmazzo/gradle-buildconfig-plugin) to not having to have the version numbers in different places, but I couldnt get it to work. 
So this is the simplest approach, but one has to change the version number in AppConfig aswell as in the gradle script.

This closes part 2 of #171