### PR TITLE
feat(gui): time line with thumbnail preview and scrollbar

### DIFF
--- a/DifferenceGenerator/src/main/kotlin/util/ColoredFrameGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/util/ColoredFrameGenerator.kt
@@ -1,0 +1,39 @@
+package util
+
+import org.bytedeco.javacv.Frame
+import wrappers.Resettable2DFrameConverter
+import java.awt.Color
+import java.awt.Graphics2D
+import java.awt.image.BufferedImage
+
+class ColoredFrameGenerator(val width: Int, val height: Int) {
+    val converter = Resettable2DFrameConverter()
+
+    /**
+     * Creates a Frame with a given color.
+     *
+     * @param color the color
+     * @return a frame colored in the given color
+     */
+    fun getColoredFrame(color: Color): Frame {
+        return converter.getFrame(getColoredBufferedImage(color))
+    }
+
+    /**
+     * Creates a Buffered Image with a given color.
+     *
+     * @param color the color
+     * @return a Buffered Image colored in the given color
+     */
+    fun getColoredBufferedImage(
+        color: Color,
+        type: Int = BufferedImage.TYPE_3BYTE_BGR,
+    ): BufferedImage {
+        val result = BufferedImage(width, height, type)
+        val g2d: Graphics2D = result.createGraphics()
+        g2d.paint = color
+        g2d.fillRect(0, 0, width, height)
+        g2d.dispose()
+        return result
+    }
+}

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -62,6 +62,7 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
         video1Grabber.start()
         video2Grabber.start()
         grabberDiff.start()
+
         // generate the sequences for video 1 and video 2
         // diffSequence is already generated
         generateSequences()
@@ -385,6 +386,14 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
         }
     }
 
+    /**
+     * Get the images at a certain diff index.
+     *
+     * If the index is an insertion or deletion, the corresponding bitmap will be returned.
+     *
+     * @param diffIndex [Int] containing the index of the diff.
+     * @return [List]<[ImageBitmap]> containing the bitmaps of the images.
+     */
     fun getImagesAtDiff(diffIndex: Int): List<ImageBitmap> {
         val video1Index = video1Frames[diffIndex]
         val video2Index = video2Frames[diffIndex]

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import kotlinx.coroutines.*
 import models.AppState
 import org.bytedeco.javacv.FFmpegFrameGrabber
+import util.ColoredFrameGenerator
 import wrappers.Resettable2DFrameConverter
 import java.awt.Color
 import java.awt.image.BufferedImage
@@ -47,14 +48,14 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
     var currentRelativePosition: MutableState<Double> = mutableStateOf(0.0)
 
     // containing the bitmaps of video
-    var video1Bitmaps: MutableList<ImageBitmap> = mutableListOf()
-    var video2Bitmaps: MutableList<ImageBitmap> = mutableListOf()
+    private var video1Bitmaps: MutableList<ImageBitmap> = mutableListOf()
+    private var video2Bitmaps: MutableList<ImageBitmap> = mutableListOf()
 
     var width: Int = 0
     var height: Int = 0
 
-    var insertionBitmap: ImageBitmap
-    var deletionBitmap: ImageBitmap
+    private var insertionBitmap: ImageBitmap
+    private var deletionBitmap: ImageBitmap
 
     init {
         // start the grabbers
@@ -72,21 +73,9 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
         loadVideoBitmaps(video1Grabber, video1Bitmaps)
         loadVideoBitmaps(video2Grabber, video2Bitmaps)
 
-        insertionBitmap =
-            BufferedImage(video1Grabber.imageWidth, video1Grabber.imageHeight, BufferedImage.TYPE_INT_RGB).apply {
-                createGraphics().apply {
-                    color = Color.GREEN
-                    fillRect(0, 0, video1Grabber.imageWidth, video1Grabber.imageHeight)
-                }
-            }.toComposeImageBitmap()
-
-        deletionBitmap =
-            BufferedImage(video1Grabber.imageWidth, video1Grabber.imageHeight, BufferedImage.TYPE_INT_RGB).apply {
-                createGraphics().apply {
-                    color = Color.BLUE
-                    fillRect(0, 0, video1Grabber.imageWidth, video1Grabber.imageHeight)
-                }
-            }.toComposeImageBitmap()
+        val coloredFrameGenerator = ColoredFrameGenerator(width, height)
+        insertionBitmap = coloredFrameGenerator.getColoredBufferedImage(Color.GREEN).toComposeImageBitmap()
+        deletionBitmap = coloredFrameGenerator.getColoredBufferedImage(Color.BLUE).toComposeImageBitmap()
 
         // jump to the first frame
         jumpToFrame()

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -50,6 +50,9 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
     var video1Bitmaps: MutableList<ImageBitmap> = mutableListOf()
     var video2Bitmaps: MutableList<ImageBitmap> = mutableListOf()
 
+    var width: Int = 0
+    var height: Int = 0
+
     var insertionBitmap: ImageBitmap
     var deletionBitmap: ImageBitmap
 
@@ -61,6 +64,9 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
         // generate the sequences for video 1 and video 2
         // diffSequence is already generated
         generateSequences()
+
+        width = grabberDiff.imageWidth
+        height = grabberDiff.imageHeight
 
         // fill the list with bitmaps
         loadVideoBitmaps(video1Grabber, video1Bitmaps)
@@ -388,10 +394,6 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
             // add the bitmap to the list
             bitmapList.add(bitmap)
         }
-    }
-
-    fun getFrameSize(): Pair<Int, Int> {
-        return Pair(grabberDiff.imageWidth, grabberDiff.imageHeight)
     }
 
     fun getImagesAtDiff(diffIndex: Int): List<ImageBitmap> {

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -361,4 +361,8 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
             bitmapList.add(bitmap)
         }
     }
+
+    fun getFrameSize(): Pair<Int, Int> {
+        return Pair(grabberDiff.imageWidth, grabberDiff.imageHeight)
+    }
 }

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -39,6 +39,7 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
 
     // state variables for the current frame index
     var currentIndex: Int = 0
+    var currentDiffIndex: MutableState<Int> = mutableStateOf(0)
     var jumpLock = false
 
     // holds the relative position of the current frame in the diff video
@@ -222,6 +223,7 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
                 diffBitmap.value = b3!!
             }
             currentIndex = coercedIndex
+            currentDiffIndex.value = currentIndex
             jumpLock = false
         }
     }

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -53,6 +53,8 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
     private var insertionBitmap: ImageBitmap
     private var deletionBitmap: ImageBitmap
 
+    private var onNavigateCallback: () -> Unit = {}
+
     init {
         // start the grabbers
         video1Grabber.start()
@@ -213,6 +215,8 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
             currentIndex = coercedIndex
             currentDiffIndex.value = currentIndex
             jumpLock = false
+        }.invokeOnCompletion {
+            onNavigateCallback()
         }
     }
 
@@ -379,5 +383,9 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
                 getBitmap(video1Grabber)
             }
         return listOf(video1Bitmap, video2Bitmap)
+    }
+
+    fun setOnNavigateCallback(callback: () -> Unit) {
+        onNavigateCallback = callback
     }
 }

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigationInterface.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigationInterface.kt
@@ -1,5 +1,3 @@
-
-
 /**
  * Provides navigation methods for frames in a video.
  *

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -1,16 +1,17 @@
 package ui.components.diffScreen
 
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.*
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -39,6 +40,8 @@ fun Timeline(navigator: FrameNavigation) {
     // width of text component to center the current percentage over the cursor
     var cursorOffset = Offset.Zero
 
+    var stateHorizontal = rememberScrollState(0)
+
     fun jumpPercentageHandler(offset: Offset) {
         cursorOffset = offset
         navigatorUpdated.jumpToPercentage((cursorOffset.x.toDouble() / componentWidth).coerceIn(0.0, 1.0))
@@ -56,7 +59,7 @@ fun Timeline(navigator: FrameNavigation) {
                 Modifier
                     .background(color = Color.LightGray)
                     .fillMaxWidth(0.8f)
-                    .height(100.dp)
+                    .height(200.dp)
                     .weight(1f)
                     .border(
                         width = 2.dp,
@@ -81,12 +84,48 @@ fun Timeline(navigator: FrameNavigation) {
             // #### red line ####
             DrawRedLine(currentOffset)
             // #### clickable timeline ####
+            Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                TimelineThumbnails(modifier = Modifier.weight(0.5f))
+                TimelineThumbnails(modifier = Modifier.weight(0.5f))
+            }
+        }
+
+        HorizontalScrollbar(
+            modifier = Modifier.fillMaxWidth(0.8f).padding(top = 5.dp).border(width = 1.dp, color = Color.LightGray, shape = CircleShape),
+            adapter = rememberScrollbarAdapter(stateHorizontal),
+            style =
+                ScrollbarStyle(
+                    // width of the scrollbar (horizontal scrollbar)
+                    minimalHeight = 80.dp,
+                    // height of the scrollbar (horizontal scrollbar)
+                    thickness = 15.dp,
+                    shape = CircleShape,
+                    hoverDurationMillis = 0,
+                    hoverColor = Color.LightGray,
+                    unhoverColor = Color.LightGray,
+                ),
+        )
+    }
+}
+
+@Composable
+private fun TimelineThumbnails(modifier: Modifier) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .border(width = 1.dp, color = Color.Black, shape = RectangleShape),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        for (i in 0..12) {
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier =
+                    Modifier
+                        .fillMaxHeight()
+                        .width(80.dp)
+                        .border(width = 1.dp, color = Color.Black, shape = RectangleShape),
             ) {
-                AlignedSizedText("0%", Alignment.CenterStart, 20.dp)
-                AlignedSizedText("50%", Alignment.Center, 20.dp)
-                AlignedSizedText("100%", Alignment.CenterEnd, 20.dp)
+                Text("Thumbnail")
             }
         }
     }
@@ -125,7 +164,7 @@ private fun TimelineTopLabels(
     var textWidth by remember { mutableStateOf(0f) }
     // Labels Container
     Box(
-        modifier = Modifier.fillMaxWidth(0.8f).fillMaxHeight(0.3f),
+        modifier = Modifier.fillMaxWidth(0.8f).fillMaxHeight(0.2f),
     ) {
         // Starting Label
         AlignedSizedText("0", Alignment.CenterStart, 2.dp)

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import frameNavigation.FrameNavigation
+import kotlinx.coroutines.launch
 import ui.components.general.AutoSizeText
 
 /**
@@ -64,6 +65,7 @@ class ThumbnailCache(val maxCacheSize: Int, val getImages: (Int) -> List<ImageBi
 @Composable
 fun Timeline(navigator: FrameNavigation) {
     val navigatorUpdated by rememberUpdatedState(navigator)
+    val scope = rememberCoroutineScope()
     // set the width of the timeline box
     var componentWidth by remember { mutableStateOf(0.0f) }
     var componentHeight by remember { mutableStateOf(0.0f) }
@@ -102,6 +104,17 @@ fun Timeline(navigator: FrameNavigation) {
 
     // set the modifier applied to all timeline components
     val generalModifier = Modifier.fillMaxWidth(0.8f)
+
+    navigator.setOnNavigateCallback {
+        indicatorOffset = getCenteredThumbnailOffset(scrollState, navigator.currentDiffIndex.value, thumbnailWidth)
+
+        if (indicatorOffset < 0 || indicatorOffset > componentWidth) {
+            scope.launch {
+                val thumbnailsInView = (componentWidth / thumbnailWidth).toInt()
+                scrollState.animateScrollToItem((navigator.currentDiffIndex.value - thumbnailsInView / 2).coerceIn(0, totalDiffFrames - 1))
+            }
+        }
+    }
 
     Column(
         modifier = Modifier.background(color = Color.Gray).fillMaxSize(),

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -38,10 +38,8 @@ fun Timeline(navigator: FrameNavigation) {
     val scrollState = rememberLazyListState()
     var thumbnailWidth by remember { mutableStateOf(0.0f) }
 
-    val frameSize: Pair<Int, Int> = navigatorUpdated.getFrameSize()
-    val totalDiffFrames = navigatorUpdated.getSizeOfDiff()
-
     var indicatorOffset by remember { mutableStateOf(0.0f) }
+    val totalDiffFrames = navigator.getSizeOfDiff()
 
     fun jumpOffsetHandler(offset: Offset) {
         cursorOffset = offset
@@ -62,7 +60,7 @@ fun Timeline(navigator: FrameNavigation) {
     }
 
     fun getThumbnailWidth(): Float {
-        return frameSize.first.toFloat() / frameSize.second * componentHeight * 0.5f
+        return navigator.width.toFloat() / navigator.height * componentHeight * 0.5f
     }
 
     indicatorOffset = getIndicatorOffset()

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -5,12 +5,12 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.layout
@@ -85,8 +85,8 @@ fun Timeline(navigator: FrameNavigation) {
             DrawRedLine(currentOffset)
             // #### clickable timeline ####
             Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(5.dp)) {
-                TimelineThumbnails(modifier = Modifier.weight(0.5f))
-                TimelineThumbnails(modifier = Modifier.weight(0.5f))
+                TimelineThumbnails(modifier = Modifier.weight(0.5f), bitmaps = navigator.video1Bitmaps)
+                TimelineThumbnails(modifier = Modifier.weight(0.5f), bitmaps = navigator.video2Bitmaps)
             }
         }
 
@@ -109,23 +109,31 @@ fun Timeline(navigator: FrameNavigation) {
 }
 
 @Composable
-private fun TimelineThumbnails(modifier: Modifier) {
+private fun TimelineThumbnails(
+    modifier: Modifier,
+    bitmaps: MutableList<ImageBitmap>,
+) {
     Row(
         modifier =
             modifier
                 .fillMaxWidth()
                 .border(width = 1.dp, color = Color.Black, shape = RectangleShape),
-        horizontalArrangement = Arrangement.SpaceEvenly,
     ) {
-        for (i in 0..12) {
+        for (i in 0 until bitmaps.size) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxHeight()
-                        .width(80.dp)
+                        .weight(1f)
                         .border(width = 1.dp, color = Color.Black, shape = RectangleShape),
             ) {
-                Text("Thumbnail")
+                Image(
+                    bitmap = bitmaps[i],
+                    contentDescription = null,
+                    modifier =
+                        Modifier
+                            .fillMaxSize(),
+                )
             }
         }
     }

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -21,20 +21,23 @@ import ui.components.general.AutoSizeText
 
 /**
  * A Composable function that creates a box to display the timeline.
- * @param navigator [FrameNavigation] containing the navigator.
+ * @param navigator [FrameNavigation] containing the navigation logic.
  * @return [Unit]
  */
 @Composable
 fun Timeline(navigator: FrameNavigation) {
     val navigatorUpdated by rememberUpdatedState(navigator)
-    // set the width of the timelinebox
+    // set the width of the timeline box
     var componentWidth by remember { mutableStateOf(0.0f) }
     var componentHeight by remember { mutableStateOf(0.0f) }
 
     // width of text component to center the current percentage over the cursor
     var cursorOffset = Offset.Zero
 
+    // scroll state of the timeline
     val scrollState = rememberLazyListState()
+
+    // display width of a single thumbnail in the timeline (2 thumbnails are stacked)
     var thumbnailWidth by remember { mutableStateOf(0.0f) }
 
     var indicatorOffset by remember { mutableStateOf(0.0f) }
@@ -131,6 +134,14 @@ fun Timeline(navigator: FrameNavigation) {
     }
 }
 
+/**
+ * Calculates the offset of the thumbnail center from the left side of the timeline.
+ *
+ * @param scrollState [LazyListState] containing the scroll state of the timeline.
+ * @param thumbnailIndex [Int] containing the index of the thumbnail in the diff sequence.
+ * @param thumbnailWidth [Float] containing the width of all thumbnails.
+ * @return [Float] containing the offset of the thumbnail center from the left side of the timeline.
+ */
 fun getCenteredThumbnailOffset(
     scrollState: LazyListState,
     thumbnailIndex: Int,
@@ -142,6 +153,17 @@ fun getCenteredThumbnailOffset(
     )
 }
 
+/**
+ * A [LazyRow] that displays the thumbnails of the aligned input videos.
+ *
+ * Thumbnails are only loaded when they are visible.
+ *
+ * @param modifier [Modifier] to apply to the [LazyRow].
+ * @param navigator [FrameNavigation] object that contains the navigation logic.
+ * @param nFrames [Int] The number of frames in the diff sequence.
+ * @param scrollState [LazyListState] containing the scroll state of the timeline.
+ * @return [Unit]
+ */
 @Composable
 private fun TimelineThumbnails(
     modifier: Modifier,
@@ -176,6 +198,12 @@ private fun TimelineThumbnails(
     }
 }
 
+/**
+ * A vertical line that indicates the current position in the timeline.
+ *
+ * @param offset [Float] The offset of the line from the left side of the timeline.
+ * @return [Unit]
+ */
 @Composable
 private fun PositionIndicator(offset: Float) {
     Canvas(modifier = Modifier.fillMaxSize()) {
@@ -188,6 +216,15 @@ private fun PositionIndicator(offset: Float) {
     }
 }
 
+/**
+ * Labels that are drawn above the center points of timeline thumbnails.
+ *
+ * @param scrollState [LazyListState] containing the scroll state of the timeline.
+ * @param thumbnailWidth [Float] containing the width of all thumbnails.
+ * @param componentWidth [Float] containing the width of the timeline component.
+ * @param modifier [Modifier] to apply to the element.
+ * @return [Unit]
+ */
 @Composable
 private fun TimelineTopLabels(
     scrollState: LazyListState,

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -148,8 +148,8 @@ fun getCenteredThumbnailOffset(
     thumbnailWidth: Float,
 ): Float {
     return (
-        (thumbnailIndex - scrollState.firstVisibleItemIndex) *
-            thumbnailWidth + thumbnailWidth / 2 - scrollState.firstVisibleItemScrollOffset
+        (thumbnailIndex - scrollState.firstVisibleItemIndex + 0.5f) *
+            thumbnailWidth - scrollState.firstVisibleItemScrollOffset
     )
 }
 
@@ -249,8 +249,9 @@ private fun TimelineTopLabels(
             }
 
             // draw label with diff index
-            AlignedSizedText(
+            AutoSizeText(
                 text = i.toString(),
+                color = Color.Black,
                 modifier =
                     Modifier
                         .onGloballyPositioned { coordinates ->
@@ -272,24 +273,4 @@ private fun TimelineTopLabels(
             }
         }
     }
-}
-
-/**
- * A Composable function that creates a text component with a given alignment and padding.
- * @param text [String] containing the text to display.
- * @param alignment [Alignment] containing the alignment of the text.
- * @param padding [Dp] containing the padding of the text.
- * @param modifier [Modifier] containing the modifier of the text.
- * @return [Unit]
- */
-@Composable
-fun AlignedSizedText(
-    text: String,
-    modifier: Modifier = Modifier,
-) {
-    AutoSizeText(
-        text = text,
-        color = Color.Black,
-        modifier = modifier,
-    )
 }

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -290,7 +290,7 @@ private fun TimelineTopLabels(
 
     // Labels Container
     Box(modifier = modifier) {
-        val lastVisibleIndex = scrollState.firstVisibleItemIndex + scrollState.layoutInfo.visibleItemsInfo.size
+        val lastVisibleIndex = scrollState.firstVisibleItemIndex + scrollState.layoutInfo.visibleItemsInfo.size - 1
 
         // thumbnail labels with ticks over thumbnail centers
         for (i in scrollState.firstVisibleItemIndex..lastVisibleIndex) {

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -121,6 +121,12 @@ fun Timeline(navigator: FrameNavigation) {
                     .padding(top = 5.dp)
                     .border(width = 1.dp, color = Color.LightGray, shape = CircleShape),
             adapter = rememberScrollbarAdapter(scrollState = scrollState),
+            style =
+                LocalScrollbarStyle.current.copy(
+                    hoverDurationMillis = 500,
+                    unhoverColor = Color.LightGray,
+                    hoverColor = Color.White,
+                ),
         )
     }
 }

--- a/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/Timeline.kt
@@ -29,8 +29,8 @@ import ui.components.general.AutoSizeText
 class ThumbnailCache(val maxCacheSize: Int, val getImages: (Int) -> List<ImageBitmap>) {
     private val cache = mutableMapOf<Int, List<ImageBitmap>>()
 
-    // queue of diff indices ordered by most recently used
-    private val usageQueue = mutableListOf<Int>()
+    // kind of a queue of diff indices ordered by most recently used
+    private val recentlyUsed = mutableListOf<Int>()
 
     /**
      * Returns the thumbnails for a given diff index.
@@ -41,18 +41,18 @@ class ThumbnailCache(val maxCacheSize: Int, val getImages: (Int) -> List<ImageBi
      * @return [List]<[ImageBitmap]> containing the thumbnails for the given diff index.
      */
     fun get(index: Int): List<ImageBitmap> {
-        usageQueue.remove(index)
+        recentlyUsed.remove(index)
 
         if (!cache.containsKey(index)) {
             cache[index] = getImages(index)
         }
 
         // if the queue is full, remove the least recently used item
-        if (usageQueue.size >= maxCacheSize) {
-            cache.remove(usageQueue.removeAt(0))
+        if (recentlyUsed.size >= maxCacheSize) {
+            cache.remove(recentlyUsed.removeAt(0))
         }
 
-        usageQueue.add(index)
+        recentlyUsed.add(index)
         return cache[index]!!
     }
 }


### PR DESCRIPTION
Closes #122.

- [x] Implement general layout
- [x] Load correct thumbnails
- [x] Show section depending on scrollstate
- [x] Adapt onClick of timeline
- [x] Adapt navigation behaviour of the timeline when pressing buttons
- [x] Dynamically choose number of frames to show at the same time
- [x] Fix scrollbar overscroll bug
- [x] Place time line indicator on center of thumbnails
- [x] Spread frames over timeline evenly with short (<10 frames) videos 
- [x] Simple thumbnail cache
- [x] Show diff indices above timeline
- [x] Refactor insertion/deletion bitmap creation to lib2
- [x] Mouse wheel scroll on timeline (works with Shift+Scroll Up/down)
- [ ] Update user documentation