### PR TITLE
refactor: rename video1/2 to reference/current

### DIFF
--- a/DifferenceGenerator/src/main/kotlin/AbstractDifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/AbstractDifferenceGenerator.kt
@@ -1,20 +1,11 @@
 /**
  * Abstract class for the DifferenceGenerator.
  *
- * @param video1Path the path to the first video
- * @param video2Path the path to the second video
+ * @param videoReferencePath the path to the reference video
+ * @param videoCurrentPath the path to the current video
  * @param outputPath the path to the output file
  */
-abstract class AbstractDifferenceGenerator(
-    video1Path: String,
-    video2Path: String,
-    outputPath: String,
-    maskPath: String?,
-) {
-    private val video1Path: String = video1Path
-    private val video2Path: String = video2Path
-    private val outputPath: String = outputPath
-
+abstract class AbstractDifferenceGenerator {
     /**
      * Generates the difference between the two videos.
      *

--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -94,8 +94,8 @@ class DifferenceGenerator(
      * Uses the algorithm given in the constructor to align the frames of both videos.
      *
      * The resulting video consists of frames which are one of types:
-     *  - only blue pixels: a frame was deleted (only in first video)
-     *  - only green pixels: a frame was inserted (only in second video)
+     *  - only blue pixels: a frame was deleted (only in reference video)
+     *  - only green pixels: a frame was inserted (only in current video)
      *  - red and black pixels: a frame was modified (both videos contain the frame)
      */
     override fun generateDifference() {

--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -16,19 +16,19 @@ import java.io.File
 import kotlin.experimental.and
 
 class DifferenceGenerator(
-    video1Path: String,
-    video2Path: String,
+    videoReferencePath: String,
+    videoCurrentPath: String,
     outputPath: String,
     private val algorithm: AlignmentAlgorithm<BufferedImage>,
     maskPath: String? = null,
-) : AbstractDifferenceGenerator(video1Path, video2Path, outputPath, maskPath) {
+) : AbstractDifferenceGenerator() {
     private val outputFile = File(outputPath)
-    private val video1File = File(video1Path)
-    private val video2File = File(video2Path)
+    private val videoReferenceFile = File(videoReferencePath)
+    private val videoCurrentFile = File(videoCurrentPath)
     private val maskFile = if (maskPath != null) File(maskPath) else null
 
-    private var video1Grabber: MaskedImageGrabber = MaskedImageGrabber(video1File, null)
-    private var video2Grabber: MaskedImageGrabber = MaskedImageGrabber(video2File, null)
+    private var videoReferenceGrabber: MaskedImageGrabber = MaskedImageGrabber(videoReferenceFile, null)
+    private var videoCurrentGrabber: MaskedImageGrabber = MaskedImageGrabber(videoCurrentFile, null)
 
     private val converter = Resettable2DFrameConverter()
     private var coloredFrameGenerator: ColoredFrameGenerator
@@ -45,18 +45,18 @@ class DifferenceGenerator(
      * @throws Exception if the videos are not in an [AcceptedCodecs.ACCEPTED_CODECS].
      */
     init {
-        if (!isLosslessCodec(video1Grabber) || !isLosslessCodec(video2Grabber)) {
+        if (!isLosslessCodec(videoReferenceGrabber) || !isLosslessCodec(videoCurrentGrabber)) {
             throw Exception("Videos must be in a lossless codec")
         }
 
-        if (this.video1Grabber.imageWidth != this.video2Grabber.imageWidth ||
-            this.video1Grabber.imageHeight != this.video2Grabber.imageHeight
+        if (this.videoReferenceGrabber.imageWidth != this.videoCurrentGrabber.imageWidth ||
+            this.videoReferenceGrabber.imageHeight != this.videoCurrentGrabber.imageHeight
         ) {
             throw Exception("Videos must have the same dimensions")
         }
 
-        this.width = this.video1Grabber.imageWidth
-        this.height = this.video1Grabber.imageHeight
+        this.width = this.videoReferenceGrabber.imageWidth
+        this.height = this.videoReferenceGrabber.imageHeight
         coloredFrameGenerator = ColoredFrameGenerator(this.width, this.height)
         mask =
             if (maskFile == null) {
@@ -65,8 +65,8 @@ class DifferenceGenerator(
                 CompositeMask(maskFile, this.width, this.height)
             }
 
-        video1Grabber.mask = mask
-        video2Grabber.mask = mask
+        videoReferenceGrabber.mask = mask
+        videoCurrentGrabber.mask = mask
 
         // turn off verbose ffmpeg output
         avutil.av_log_set_level(avutil.AV_LOG_QUIET)
@@ -104,39 +104,39 @@ class DifferenceGenerator(
         encoder.frameRate = 1.0
         encoder.start()
 
-        alignment = algorithm.run(video1Grabber, video2Grabber)
+        alignment = algorithm.run(videoReferenceGrabber, videoCurrentGrabber)
 
         // reset the grabbers to put the iterators to the videos' beginning
-        video1Grabber.reset()
-        video2Grabber.reset()
+        videoReferenceGrabber.reset()
+        videoCurrentGrabber.reset()
 
         for (el in alignment) {
             when (el) {
                 AlignmentElement.MATCH -> {
-                    encoder.record(getDifferencesBetweenBufferedImages(video1Grabber.next(), video2Grabber.next()))
+                    encoder.record(getDifferencesBetweenBufferedImages(videoReferenceGrabber.next(), videoCurrentGrabber.next()))
                 }
                 AlignmentElement.INSERTION -> {
                     encoder.record(coloredFrameGenerator.getColoredFrame(Color.GREEN))
-                    video2Grabber.next()
+                    videoCurrentGrabber.next()
                 }
                 AlignmentElement.DELETION -> {
                     encoder.record(coloredFrameGenerator.getColoredFrame(Color.BLUE))
-                    video1Grabber.next()
+                    videoReferenceGrabber.next()
                 }
                 AlignmentElement.PERFECT -> {
                     encoder.record(coloredFrameGenerator.getColoredFrame(Color.BLACK))
-                    video1Grabber.next()
-                    video2Grabber.next()
+                    videoReferenceGrabber.next()
+                    videoCurrentGrabber.next()
                 }
             }
         }
         encoder.stop()
         encoder.release()
 
-        video1Grabber.stop()
-        video2Grabber.stop()
-        video1Grabber.release()
-        video2Grabber.release()
+        videoReferenceGrabber.stop()
+        videoCurrentGrabber.stop()
+        videoReferenceGrabber.release()
+        videoCurrentGrabber.release()
     }
 
     /**

--- a/DifferenceGenerator/src/test/kotlin/DifferenceGeneratorTest.kt
+++ b/DifferenceGenerator/src/test/kotlin/DifferenceGeneratorTest.kt
@@ -58,8 +58,8 @@ internal class DifferenceGeneratorTest {
             gapExtension = it.toDouble()
         }
         print("Gap Open Penalty: $gapOpen, Gap Extension Penalty: $gapExtension, Iterations: $iterations")
-        val pathVideo1 = resourcesPathPrefix + "generatedVideo1.mkv"
-        val pathVideo2 = resourcesPathPrefix + "generatedVideo2.mkv"
+        val pathVideoReference = resourcesPathPrefix + "generatedVideo1.mkv"
+        val pathVideoCurrent = resourcesPathPrefix + "generatedVideo2.mkv"
         val outputPath = resourcesPathPrefix + "generatedOutput.mkv"
         var algorithm: AlignmentAlgorithm<BufferedImage> = Gotoh<BufferedImage>(metric, gapOpenPenalty = -0.5, gapExtensionPenalty = -0.0)
 
@@ -68,9 +68,9 @@ internal class DifferenceGeneratorTest {
 
         var allDistances = Array(iterations) { 0 }
         for (i in 0 until iterations) {
-            val testCaseGenerator = TestCaseGenerator(pathVideo1, pathVideo2, 50)
+            val testCaseGenerator = TestCaseGenerator(pathVideoReference, pathVideoCurrent, 50)
             val expectedAlignment = testCaseGenerator.generateRandomTestCase()
-            val differenceGenerator = DifferenceGenerator(pathVideo1, pathVideo2, outputPath, algorithm)
+            val differenceGenerator = DifferenceGenerator(pathVideoReference, pathVideoCurrent, outputPath, algorithm)
             val actualAlignment = differenceGenerator.alignment
             println("Calculated Alignment: " + actualAlignment.joinToString())
             println("Expected Alignment: " + expectedAlignment.joinToString())

--- a/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
+++ b/DifferenceGenerator/src/test/kotlin/ReadRuntimeTests.kt
@@ -17,8 +17,8 @@ internal class ReadRuntimeTests {
     private val resourcesPathPrefix = "src/test/resources/"
     private val video9Frames = resourcesPathPrefix + "9Screenshots.mov"
     private val modifiedVideo9Frames = resourcesPathPrefix + "9ScreenshotsModified.mov"
-    private val video1File = File(video9Frames)
-    private val video2File = File(modifiedVideo9Frames)
+    private val videoReferenceFile = File(video9Frames)
+    private val videoCurrentFile = File(modifiedVideo9Frames)
     private val runAmount = 20
 
     private val methodMap: Map<String, (Resettable2DFrameConverter, Frame, Frame, Int, Int) -> Int> =
@@ -42,7 +42,7 @@ internal class ReadRuntimeTests {
         var difs = 0
         val method = methodMap[methodName] ?: throw Exception("Method not found")
         for (i in 0 until runs) {
-            val (differences, time) = wrapper(video1File, video2File, method)
+            val (differences, time) = wrapper(videoReferenceFile, videoCurrentFile, method)
             totalTime += time
             difs += differences
         }
@@ -61,30 +61,30 @@ internal class ReadRuntimeTests {
         vid2: File,
         method: (Resettable2DFrameConverter, Frame, Frame, Int, Int) -> Int,
     ): Pair<Int, Long> {
-        val video1Grabber = FFmpegFrameGrabber(vid1)
-        val video2Grabber = FFmpegFrameGrabber(vid2)
+        val videoReferenceGrabber = FFmpegFrameGrabber(vid1)
+        val videoCurrentGrabber = FFmpegFrameGrabber(vid2)
 
-        video1Grabber.start()
-        video2Grabber.start()
+        videoReferenceGrabber.start()
+        videoCurrentGrabber.start()
 
-        val width = video1Grabber.imageWidth
-        val height = video1Grabber.imageHeight
+        val width = videoReferenceGrabber.imageWidth
+        val height = videoReferenceGrabber.imageHeight
 
         val converter = Resettable2DFrameConverter()
 
-        var frame1 = video1Grabber.grabImage()
-        var frame2 = video2Grabber.grabImage()
+        var frame1 = videoReferenceGrabber.grabImage()
+        var frame2 = videoCurrentGrabber.grabImage()
         var counter = 0
         var time = 0L
 
         while (frame1 != null && frame2 != null) {
             time += measureTimeMillis { counter += method(converter, frame1, frame2, width, height) }
 
-            frame1 = video1Grabber.grabImage()
-            frame2 = video2Grabber.grabImage()
+            frame1 = videoReferenceGrabber.grabImage()
+            frame2 = videoCurrentGrabber.grabImage()
         }
-        video1Grabber.stop()
-        video2Grabber.stop()
+        videoReferenceGrabber.stop()
+        videoCurrentGrabber.stop()
         return Pair(counter, time)
     }
 

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -397,7 +397,7 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
                 deletionBitmap
             } else {
                 videoCurrentGrabber.setVideoFrameNumber(videoCurrentIndex)
-                getBitmap(videoReferenceGrabber)
+                getBitmap(videoCurrentGrabber)
             }
         return listOf(videoReferenceBitmap, videoCurrentBitmap)
     }

--- a/GUI/src/main/kotlin/logic/differenceGeneratorWrapper/DifferenceGeneratorWrapper.kt
+++ b/GUI/src/main/kotlin/logic/differenceGeneratorWrapper/DifferenceGeneratorWrapper.kt
@@ -27,8 +27,8 @@ class DifferenceGeneratorWrapper(state: MutableState<AppState>) {
 
     private var differenceGenerator: DifferenceGenerator =
         DifferenceGenerator(
-            video1Path = state.value.video1Path,
-            video2Path = state.value.video2Path,
+            videoReferencePath = state.value.videoReferencePath,
+            videoCurrentPath = state.value.videoCurrentPath,
             outputPath = state.value.outputPath,
             algorithm = divideAndConquerAligner,
             maskPath = if (state.value.maskPath == "") null else state.value.maskPath,

--- a/GUI/src/main/kotlin/models/AppState.kt
+++ b/GUI/src/main/kotlin/models/AppState.kt
@@ -11,8 +11,8 @@ import java.nio.file.FileSystems
 /**
  * This data class represents the global state of the application.
  * @param screen the current screen
- * @param video1Path the path of the first video
- * @param video2Path the path of the second video
+ * @param videoReferencePath the path of the first video
+ * @param videoCurrentPath the path of the second video
  * @param outputPath the path of the output video
  * @param saveCollagePath the last path where a collage was saved
  * @param saveProjectPath the last path where a project was saved
@@ -27,8 +27,8 @@ import java.nio.file.FileSystems
  */
 data class AppState(
     var screen: Screen = Screen.SelectVideoScreen,
-    var video1Path: String = getPath("testVideo1.mkv"),
-    var video2Path: String = getPath("testVideo2.mkv"),
+    var videoReferencePath: String = getPath("testVideo1.mkv"),
+    var videoCurrentPath: String = getPath("testVideo2.mkv"),
     var outputPath: String = getPath("output.mkv"),
     var saveCollagePath: String? = null,
     var saveProjectPath: String? = null,

--- a/GUI/src/main/kotlin/models/AppState.kt
+++ b/GUI/src/main/kotlin/models/AppState.kt
@@ -11,8 +11,8 @@ import java.nio.file.FileSystems
 /**
  * This data class represents the global state of the application.
  * @param screen the current screen
- * @param videoReferencePath the path of the first video
- * @param videoCurrentPath the path of the second video
+ * @param videoReferencePath the path of the reference video
+ * @param videoCurrentPath the path of the current video
  * @param outputPath the path of the output video
  * @param saveCollagePath the last path where a collage was saved
  * @param saveProjectPath the last path where a project was saved

--- a/GUI/src/main/kotlin/ui/components/diffScreen/StatisticalInformation.kt
+++ b/GUI/src/main/kotlin/ui/components/diffScreen/StatisticalInformation.kt
@@ -13,11 +13,11 @@ fun RowScope.StatisticalInformation(navigator: FrameNavigation) {
     Row(modifier = Modifier.weight(0.2f).fillMaxHeight().fillMaxWidth()) {
         Column {
             Text("Statistical Information:", fontSize = 12.sp, fontWeight = FontWeight.Bold)
-            Text("Total Frames Video1: ${navigator.getSizeOfVideo1()}", fontSize = 12.sp)
-            Text("Total Frames Video2: ${navigator.getSizeOfVideo2()}", fontSize = 12.sp)
+            Text("Total Frames Reference Video: ${navigator.getSizeOfVideoReference()}", fontSize = 12.sp)
+            Text("Total Frames Current Video: ${navigator.getSizeOfVideoCurrent()}", fontSize = 12.sp)
             Text("Frames with Differences: ${navigator.getFramesWithPixelDifferences()}", fontSize = 12.sp)
-            Text("added Frames: ${navigator.getInsertions()}", fontSize = 12.sp)
-            Text("deleted Frames: ${navigator.getDeletions()}", fontSize = 12.sp)
+            Text("Inserted Frames: ${navigator.getInsertions()}", fontSize = 12.sp)
+            Text("Deleted Frames: ${navigator.getDeletions()}", fontSize = 12.sp)
         }
     }
 }

--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
@@ -38,7 +38,11 @@ fun RowScope.ComputeDifferencesButton(state: MutableState<AppState>) {
             }
         },
         // enable the button only if all the paths are not empty
-        enabled = state.value.video1Path.isNotEmpty() && state.value.video2Path.isNotEmpty() && state.value.outputPath.isNotEmpty(),
+        enabled = (
+            state.value.videoReferencePath.isNotEmpty() &&
+                state.value.videoCurrentPath.isNotEmpty() &&
+                state.value.outputPath.isNotEmpty()
+        ),
     ) {
         AutoSizeText(
             text = "Compute and Display Differences",

--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/FileSelectorButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/FileSelectorButton.kt
@@ -22,7 +22,7 @@ import ui.components.general.openFileChooserAndGetPath
  * @param buttonText The text to be displayed on the button.
  * @param buttonPath The path to the selected file.
  * @param onUpdateResult A function that will be called with the selected file path as a parameter.
- * Should update the AppState with the selected file path for the chosen file(e.g. Video1Path).
+ * Should update the AppState with the selected file path for the chosen file(e.g. VideoReferencePath).
  * @param tooltipText The text to be displayed in the tooltip.
  * @param directoryPath The path to the directory to be opened in the file chooser.
  * @return [Unit]

--- a/GUI/src/main/kotlin/ui/screens/DiffScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/DiffScreen.kt
@@ -57,9 +57,9 @@ fun DiffScreen(state: MutableState<AppState>) {
 
         // #####   Titles   #####
         Row(modifier = Modifier.fillMaxWidth().weight(0.1f)) {
-            TextTitle(text = "Video 1")
+            TextTitle(text = "Reference Video")
             TextTitle(text = "Diff")
-            TextTitle(text = "Video 2")
+            TextTitle(text = "Current Video")
         }
 
         Row(modifier = Modifier.fillMaxWidth().weight(0.1f)) {
@@ -68,9 +68,9 @@ fun DiffScreen(state: MutableState<AppState>) {
 
         // #####   Difference Videos   #####
         Row(modifier = Modifier.fillMaxWidth().fillMaxHeight().weight(0.5f)) {
-            DisplayDifferenceImage(bitmap = navigator.video1Bitmap, navigator = navigator, title = "Video 1", state = state)
+            DisplayDifferenceImage(bitmap = navigator.videoReferenceBitmap, navigator = navigator, title = "Reference Video", state = state)
             DisplayDifferenceImage(bitmap = navigator.diffBitmap, navigator = navigator, title = "Diff", state = state)
-            DisplayDifferenceImage(bitmap = navigator.video2Bitmap, navigator = navigator, title = "Video 2", state = state)
+            DisplayDifferenceImage(bitmap = navigator.videoCurrentBitmap, navigator = navigator, title = "Current Video", state = state)
         }
         // #####   Timeline   #####
         Row(modifier = Modifier.fillMaxSize().weight(0.15f)) { Timeline(navigator) }

--- a/GUI/src/main/kotlin/ui/screens/DiffScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/DiffScreen.kt
@@ -18,7 +18,7 @@ import ui.components.general.TextTitle
 
 /**
  * A Composable function that creates a screen to display the differences between two videos.
- * Shows 3 videos: the first video, the difference between the two videos, and the second video.
+ * Shows 3 videos: the reference video, the difference between the two videos, and the current video.
  * Gets recomposed when the state object changes, not when state properties change.
  * @param state [MutableState]<[AppState]> containing the global state.
  * @return [Unit]

--- a/GUI/src/main/kotlin/ui/screens/SelectVideoScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SelectVideoScreen.kt
@@ -31,21 +31,21 @@ fun SelectVideoScreen(state: MutableState<AppState>) {
         // video selection
         Row(modifier = Modifier.weight(0.85f)) {
             FileSelectorButton(
-                buttonText = "Select Video 1",
-                buttonPath = state.value.video1Path,
+                buttonText = "Select Reference Video",
+                buttonPath = state.value.videoReferencePath,
                 onUpdateResult = { selectedFilePath ->
-                    state.value = state.value.copy(video1Path = selectedFilePath)
+                    state.value = state.value.copy(videoReferencePath = selectedFilePath)
                 },
-                directoryPath = state.value.video1Path,
+                directoryPath = state.value.videoReferencePath,
             )
 
             FileSelectorButton(
-                buttonText = "Select Video 2",
-                buttonPath = state.value.video2Path,
+                buttonText = "Select Current Video",
+                buttonPath = state.value.videoCurrentPath,
                 onUpdateResult = { selectedFilePath ->
-                    state.value = state.value.copy(video2Path = selectedFilePath)
+                    state.value = state.value.copy(videoCurrentPath = selectedFilePath)
                 },
-                directoryPath = state.value.video2Path,
+                directoryPath = state.value.videoCurrentPath,
             )
         }
         // screen switch buttons

--- a/GUI/src/test/kotlin/ui/SelectVideoScreenTest.kt
+++ b/GUI/src/test/kotlin/ui/SelectVideoScreenTest.kt
@@ -51,8 +51,8 @@ class SelectVideoScreenTest {
      */
     @Test
     fun `test presence of buttons`() {
-        composeTestRule.onNodeWithText("Select Video 1").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Select Video 2").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Select Reference Video").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Select Current Video").assertIsDisplayed()
         composeTestRule.onNodeWithText("Compute and Display Differences").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("settings").assertIsDisplayed()
         composeTestRule.onNodeWithText("?").assertIsDisplayed()


### PR DESCRIPTION
Closes #219.

Due to the POs wanting the name "current" for the second video, I chose to name many of the variables 
videoReference/videoCurrent instead of referenceVideo/currentVideo to avoid confusion with variables like currentIndex (e.g. FrameNavigation)