### PR TITLE
Set new version number based on sprint number

### DIFF
--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -14,8 +14,8 @@ repositories {
     mavenCentral()
 }
 
-group = "org.example"
-version = "1.0-SNAPSHOT"
+group = "amos2023ws03"
+version = "1.11.0"
 
 dependencies {
     testImplementation(kotlin("test"))

--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -12,10 +12,10 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
-group = "com.example"
+group = "amos2023ws03"
 
 // WARNING: If this value is updated, it should be updated in the AppConfig class too
-version = "1.0.0"
+version = "1.11.0"
 
 repositories {
     google()

--- a/GUI/src/main/kotlin/Main.kt
+++ b/GUI/src/main/kotlin/Main.kt
@@ -46,5 +46,5 @@ fun App() {
 }
 
 object AppConfig {
-    const val VERSION = "1.0.0" // has to be updated manually, when the version in gradle is updated
+    const val VERSION = "1.11.0" // has to be updated manually, when new version is released
 }

--- a/VideoGenerator/build.gradle.kts
+++ b/VideoGenerator/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
-group = "org.example"
-version = "1.0-SNAPSHOT"
+group = "amos2023ws03"
+version = "1.11.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
I changed the version number based on @akriese's proposal to the number of the now ending sprint.

Should be merged last before releasing.