### PR TITLE
fix: use ffmpeg standard metadata key

### DIFF
--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
@@ -119,10 +119,10 @@ fun getVideoCreationDate(videoPath: String): Long {
     val metadata = grabber.metadata
     grabber.stop()
     grabber.release()
-    var creationData = metadata.getOrDefault("CREATION-TIME", "0").toLong()
 
-    if (creationData != 0L) {
-        return creationData
+    // Expect creation_time (ffmpeg standard) to be in ISO 8601 datetime format
+    if (metadata.containsKey("creation_time")) {
+        return java.time.Instant.parse(metadata["creation_time"]!!).toEpochMilli()
     }
 
     // if metadata is not available, use file creation date

--- a/VideoGenerator/example/README.md
+++ b/VideoGenerator/example/README.md
@@ -58,5 +58,5 @@ the URL and destination File can be set in `example/app/build.gradle.kts
     - to check for available AVDs execute `emulator -list-avds`
 2. Run `./gradlew assembleDebug assembleDebugAndroidTest` to create debug and test APKs
 3. Install the debug APK on the emulator or device, e.g. `adb install -r app/build/outputs/apk/debug/app-debug.apk`
-4. Run the app on the emulator or device, e.g. `adb shell am start -n "com.example.videogenerator/com.example.videogenerator.MainActivity" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER`
+4. Run the app on the emulator or device, e.g. `adb shell am start -n "de.guiframediff.videogeneratorexample/de.guiframediff.videogeneratorexample.MainActivity" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER`
 5. Run the instrumented tests via `./gradlew connectedAndroidTest`

--- a/VideoGenerator/src/main/kotlin/VideoGeneratorImpl.kt
+++ b/VideoGenerator/src/main/kotlin/VideoGeneratorImpl.kt
@@ -4,6 +4,7 @@ import org.bytedeco.javacv.FFmpegFrameRecorder
 import org.bytedeco.javacv.Frame
 import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
+import java.time.LocalDateTime
 import javax.imageio.ImageIO
 
 /**
@@ -61,7 +62,7 @@ class VideoGeneratorImpl(
         // initialize and start Recorder
         if (!::recorder.isInitialized) {
             recorder = initializeRecorder(width, height)
-            recorder.setMetadata("CREATION-TIME", System.currentTimeMillis().toString())
+            recorder.setMetadata("creation_time", LocalDateTime.now().toString())
             recorder.start()
         }
 

--- a/VideoGenerator/src/test/kotlin/VideoGeneratorImplTests.kt
+++ b/VideoGenerator/src/test/kotlin/VideoGeneratorImplTests.kt
@@ -75,6 +75,6 @@ class VideoGeneratorImplTests {
         grabber.start()
         val metadata = grabber.metadata
         println(metadata)
-        assertTrue(metadata.containsKey("CREATION-TIME"))
+        assertTrue(metadata.containsKey("creation_time"))
     }
 }


### PR DESCRIPTION
creation_time instead of CREATION-TIME.

Apparently, this is supposed to be the standard, so we conform to how other programs set the creation time metadata key