### PR TITLE
feat(gui): nullable paths

### DIFF
--- a/GUI/README.md
+++ b/GUI/README.md
@@ -29,8 +29,8 @@ For convenience reason, the project offers an environment variable to be set to 
 for path values (videos, masks, etc.).
 Set `GUI_USE_DEFAULT_PATHS` to `true` to use the default paths before running the GUI.
 
-Windows: `set $env:GUI_USE_DEFAULT_PATHS=true`
-Shell: `export GUI_USE_DEFAULT_PATHS=true`
+- Windows: `$env:GUI_USE_DEFAULT_PATHS="true"`
+- Shell: `export GUI_USE_DEFAULT_PATHS=true`
 
 ## Testing instructions
 

--- a/GUI/README.md
+++ b/GUI/README.md
@@ -23,6 +23,15 @@
       - The videos are `src/test/resources/ExampleVideoNew.mov` and `src/test/resources/ExampleVideoReference.mov`.
       - The mask is `src/test/resources/mask1200x700.png`.
 
+### Environment variables
+
+For convenience reason, the project offers an environment variable to be set to use some defaults
+for path values (videos, masks, etc.).
+Set `GUI_USE_DEFAULT_PATHS` to `true` to use the default paths before running the GUI.
+
+Windows: `set $env:GUI_USE_DEFAULT_PATHS=true`
+Shell: `export GUI_USE_DEFAULT_PATHS=true`
+
 ## Testing instructions
 
 Tests can be found under `src/test/kotlin/`.

--- a/GUI/src/main/kotlin/Main.kt
+++ b/GUI/src/main/kotlin/Main.kt
@@ -3,7 +3,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
-import models.AppState
+import models.createAppState
 import ui.screens.DiffScreen
 import ui.screens.SelectVideoScreen
 import ui.screens.SettingsScreen
@@ -34,7 +34,13 @@ fun main(): Unit =
 @Composable
 fun App() {
     // create the global state
-    val globalState = remember { mutableStateOf(AppState()) }
+    val globalState =
+        remember {
+            mutableStateOf(
+                createAppState(useDefaultPaths = System.getenv("GUI_USE_DEFAULT_PATHS").toBoolean()),
+            )
+        }
+
     // pass the global state to the screen, access data using state.value.*
     // to update the global state, use state.value = state.value.copy(...)
     when (globalState.value.screen) {

--- a/GUI/src/main/kotlin/logic/differenceGeneratorWrapper/DifferenceGeneratorWrapper.kt
+++ b/GUI/src/main/kotlin/logic/differenceGeneratorWrapper/DifferenceGeneratorWrapper.kt
@@ -26,11 +26,11 @@ class DifferenceGeneratorWrapper(state: MutableState<AppState>) {
 
     private var differenceGenerator: DifferenceGenerator =
         DifferenceGenerator(
-            videoReferencePath = state.value.videoReferencePath,
-            videoCurrentPath = state.value.videoCurrentPath,
-            outputPath = state.value.outputPath,
+            videoReferencePath = state.value.videoReferencePath!!,
+            videoCurrentPath = state.value.videoCurrentPath!!,
+            outputPath = state.value.outputPath!!,
             algorithm = divideAndConquerAligner,
-            maskPath = if (state.value.maskPath == "") null else state.value.maskPath,
+            maskPath = state.value.maskPath,
         )
 
     /**

--- a/GUI/src/main/kotlin/models/AppState.kt
+++ b/GUI/src/main/kotlin/models/AppState.kt
@@ -56,6 +56,18 @@ object JsonMapper {
         }
 }
 
+fun createAppState(useDefaultPaths: Boolean): AppState {
+    if (useDefaultPaths) {
+        return AppState(
+            videoReferencePath = getPath("testVideo1.mkv"),
+            videoCurrentPath = getPath("testVideo2.mkv"),
+            outputPath = getPath("output.mkv"),
+            maskPath = getPath("mask.png"),
+        )
+    }
+    return AppState()
+}
+
 /**
  *  TODO: remove this function
  *  This function is used to get the path of a file in the resources folder.

--- a/GUI/src/main/kotlin/models/AppState.kt
+++ b/GUI/src/main/kotlin/models/AppState.kt
@@ -29,15 +29,15 @@ val defaultOutputPath = getPath("output.mkv")
  */
 data class AppState(
     var screen: Screen = Screen.SelectVideoScreen,
-    var videoReferencePath: String = getPath("testVideo1.mkv"),
-    var videoCurrentPath: String = getPath("testVideo2.mkv"),
-    var outputPath: String = defaultOutputPath,
+    var videoReferencePath: String? = null,
+    var videoCurrentPath: String? = null,
+    var outputPath: String? = null,
     var saveCollagePath: String? = null,
     var saveProjectPath: String? = null,
     var openProjectPath: String? = null,
     var saveFramePath: String? = null,
     var saveInsertionsPath: String? = null,
-    var maskPath: String = getPath("mask.png"),
+    var maskPath: String? = null,
     var sequenceObj: Array<AlignmentElement> = arrayOf(),
     var gapOpenPenalty: Double = 0.2,
     var gapExtendPenalty: Double = -0.8,
@@ -61,7 +61,7 @@ fun createAppState(useDefaultPaths: Boolean): AppState {
         return AppState(
             videoReferencePath = getPath("testVideo1.mkv"),
             videoCurrentPath = getPath("testVideo2.mkv"),
-            outputPath = getPath("output.mkv"),
+            outputPath = defaultOutputPath,
             maskPath = getPath("mask.png"),
         )
     }

--- a/GUI/src/main/kotlin/models/AppState.kt
+++ b/GUI/src/main/kotlin/models/AppState.kt
@@ -7,6 +7,7 @@ import algorithms.AlignmentElement
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import java.nio.file.FileSystems
+import kotlin.io.path.pathString
 
 val defaultOutputPath = getPath("output.mkv")
 
@@ -56,6 +57,14 @@ object JsonMapper {
         }
 }
 
+/**
+ * Creates an [AppState] object with default values.
+ *
+ * We always need the output path, so we don't use the test-sources path for it,
+ * a temp file is used.
+ *
+ * @param useDefaultPaths whether to use the convenience paths or not.
+ */
 fun createAppState(useDefaultPaths: Boolean): AppState {
     if (useDefaultPaths) {
         return AppState(
@@ -65,7 +74,7 @@ fun createAppState(useDefaultPaths: Boolean): AppState {
             maskPath = getPath("mask.png"),
         )
     }
-    return AppState()
+    return AppState(outputPath = kotlin.io.path.createTempFile("guiFrameDiffOutput", suffix = ".mkv").pathString)
 }
 
 /**

--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
@@ -29,7 +29,6 @@ import java.nio.file.attribute.BasicFileAttributes
  * @param state [AppState] object containing the state of the application.
  * @return [Unit]
  */
-
 @Composable
 fun RowScope.ComputeDifferencesButton(
     state: MutableState<AppState>,
@@ -56,9 +55,9 @@ fun RowScope.ComputeDifferencesButton(
         },
         // enable the button only if all the paths are not empty
         enabled = (
-            state.value.videoReferencePath.isNotEmpty() &&
-                state.value.videoCurrentPath.isNotEmpty() &&
-                state.value.outputPath.isNotEmpty()
+            state.value.videoReferencePath != null &&
+                state.value.videoCurrentPath != null &&
+                state.value.outputPath != null
         ),
     ) {
         AutoSizeText(
@@ -98,7 +97,7 @@ private fun calculateVideoDifferences(
         }
 
         try {
-            generator.getDifferences(state.value.outputPath)
+            generator.getDifferences(state.value.outputPath!!)
         } catch (e: DifferenceGeneratorStoppedException) {
             println("stopped by canceling...")
             return@launch
@@ -136,7 +135,7 @@ fun getVideoCreationDate(videoPath: String): Long {
 }
 
 fun referenceIsOlderThanCurrent(state: MutableState<AppState>): Boolean {
-    val creationDate1 = getVideoCreationDate(state.value.videoReferencePath)
-    val creationDate2 = getVideoCreationDate(state.value.videoCurrentPath)
+    val creationDate1 = getVideoCreationDate(state.value.videoReferencePath!!)
+    val creationDate2 = getVideoCreationDate(state.value.videoCurrentPath!!)
     return creationDate1 < creationDate2
 }

--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/FileSelectorButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/FileSelectorButton.kt
@@ -30,7 +30,7 @@ import ui.components.general.openFileChooserAndGetPath
 @Composable
 fun RowScope.FileSelectorButton(
     buttonText: String,
-    buttonPath: String,
+    buttonPath: String?,
     onUpdateResult: (String) -> Unit,
     tooltipText: String? = null,
     directoryPath: String? = null,
@@ -56,7 +56,7 @@ fun RowScope.FileSelectorButton(
             // row to display the button text
             Row(modifier = Modifier.weight(0.15f)) { AutoSizeText(text = buttonText) }
             // row to display the selected file path
-            Row(modifier = Modifier.weight(0.1f)) { AutoSizeText(text = buttonPath, minimalFontSize = 20) }
+            Row(modifier = Modifier.weight(0.1f)) { AutoSizeText(text = buttonPath ?: "No file selected", minimalFontSize = 20) }
         }
     }
 }

--- a/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
+++ b/GUI/src/main/kotlin/ui/screens/SettingsScreen.kt
@@ -1,12 +1,10 @@
 package ui.screens
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import models.AppState
-import ui.components.*
 import ui.components.general.TextTitle
 import ui.components.general.TitleWithInfo
 import ui.components.selectVideoScreen.FileSelectorButton
@@ -18,7 +16,6 @@ import ui.components.settingsScreen.SaveButton
  * SettingsScreen is the screen where the user can change the settings of the app.
  *
  * @param state the state of the app
- * @param oldState the previous state of the app
  */
 @Composable
 fun SettingsScreen(state: MutableState<AppState>) {


### PR DESCRIPTION
This makes app state paths nullable and introduces an env variable `GUI_USE_DEFAULT_PATHS` that can be set to use some default paths for convenience. Read more in [`./GUI/README.md`](https://github.com/amosproj/amos2023ws03-gui-frame-diff/tree/gui/feature/nullable-paths/GUI#readme)