### PR TITLE
feat: more information in exceptions

### DIFF
--- a/DifferenceGenerator/src/main/kotlin/AcceptedCodecs.kt
+++ b/DifferenceGenerator/src/main/kotlin/AcceptedCodecs.kt
@@ -23,16 +23,22 @@ class AcceptedCodecs {
         /**
          * Checks if the given file is in an accepted codec.
          */
-        public fun checkFile(path: String): Boolean {
-            val grabber = FFmpegFrameGrabber(path)
-            grabber.start()
-            val codecName = grabber.videoMetadata["encoder"] ?: grabber.videoCodecName
+        fun checkFile(path: String): Boolean {
+            val codecName = getCodec(path)
             for (codec in ACCEPTED_CODECS) {
                 if (codecName.contains(codec, ignoreCase = true)) {
                     return true
                 }
             }
             return false
+        }
+
+        fun getCodec(path: String): String {
+            val grabber = FFmpegFrameGrabber(path)
+            grabber.start()
+            val codecName = grabber.videoMetadata["encoder"] ?: grabber.videoCodecName
+            grabber.close()
+            return codecName
         }
     }
 }

--- a/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/DifferenceGenerator.kt
@@ -6,6 +6,7 @@ import org.bytedeco.ffmpeg.global.avcodec.AV_CODEC_ID_FFV1
 import org.bytedeco.ffmpeg.global.avutil
 import org.bytedeco.javacv.FFmpegFrameRecorder
 import org.bytedeco.javacv.Frame
+import org.opencv.core.Size
 import util.ColoredFrameGenerator
 import wrappers.MaskedImageGrabber
 import wrappers.Resettable2DFrameConverter
@@ -46,14 +47,29 @@ class DifferenceGenerator(
      * @throws DifferenceGeneratorDimensionException if the videos' dimensions don't match.
      */
     init {
-        if (!AcceptedCodecs.checkFile(videoReferencePath) || !AcceptedCodecs.checkFile(videoCurrentPath)) {
-            throw DifferenceGeneratorCodecException("Videos must be in a lossless codec")
+        if (!AcceptedCodecs.checkFile(videoReferencePath)) {
+            throw DifferenceGeneratorCodecException(
+                "Reference video must be in a lossless codec",
+                actualCodec = AcceptedCodecs.getCodec(videoReferencePath),
+                expectedCodecs = AcceptedCodecs.ACCEPTED_CODECS.toList(),
+            )
+        }
+        if (!AcceptedCodecs.checkFile(videoCurrentPath)) {
+            throw DifferenceGeneratorCodecException(
+                "Current video must be in a lossless codec",
+                actualCodec = AcceptedCodecs.getCodec(videoCurrentPath),
+                expectedCodecs = AcceptedCodecs.ACCEPTED_CODECS.toList(),
+            )
         }
 
         if (this.videoReferenceGrabber.imageWidth != this.videoCurrentGrabber.imageWidth ||
             this.videoReferenceGrabber.imageHeight != this.videoCurrentGrabber.imageHeight
         ) {
-            throw DifferenceGeneratorDimensionException("Videos must have the same dimensions")
+            throw DifferenceGeneratorDimensionException(
+                "Videos must have the same dimensions",
+                referenceSize = Size(this.videoReferenceGrabber.imageWidth.toDouble(), this.videoReferenceGrabber.imageHeight.toDouble()),
+                currentSize = Size(this.videoCurrentGrabber.imageWidth.toDouble(), this.videoCurrentGrabber.imageHeight.toDouble()),
+            )
         }
 
         this.width = this.videoReferenceGrabber.imageWidth

--- a/DifferenceGenerator/src/main/kotlin/Exceptions.kt
+++ b/DifferenceGenerator/src/main/kotlin/Exceptions.kt
@@ -1,4 +1,4 @@
-
+import org.opencv.core.Size
 
 /**
  * Base class for all exceptions thrown by the library.
@@ -18,9 +18,14 @@ open class DifferenceGeneratorException(message: String, cause: Throwable? = nul
  * @param message the detail message.
  * @param cause the cause.
  */
-class DifferenceGeneratorCodecException(message: String, cause: Throwable? = null) : DifferenceGeneratorException(message, cause) {
+class DifferenceGeneratorCodecException(
+    message: String,
+    cause: Throwable? = null,
+    val actualCodec: String,
+    val expectedCodecs: List<String>,
+) : DifferenceGeneratorException(message, cause) {
     override fun toString(): String {
-        return "CodecException(message=$message, cause=$cause)"
+        return "$message:\n The used codec: $actualCodec; expected codecs: ${expectedCodecs.joinToString(" | ")}})"
     }
 }
 
@@ -30,21 +35,14 @@ class DifferenceGeneratorCodecException(message: String, cause: Throwable? = nul
  * @param message the detail message.
  * @param cause the cause.
  */
-class DifferenceGeneratorDimensionException(message: String, cause: Throwable? = null) : DifferenceGeneratorException(message, cause) {
+class DifferenceGeneratorDimensionException(
+    message: String,
+    cause: Throwable? = null,
+    val referenceSize: Size,
+    val currentSize: Size,
+) : DifferenceGeneratorException(message, cause) {
     override fun toString(): String {
-        return "DimensionException(message=$message, cause=$cause)"
-    }
-}
-
-/**
- * Exception thrown when the video container is not supported.
- *
- * @param message the detail message.
- * @param cause the cause.
- */
-class DifferenceGeneratorContainerException(message: String, cause: Throwable? = null) : DifferenceGeneratorException(message, cause) {
-    override fun toString(): String {
-        return "ContainerException(message=$message, cause=$cause)"
+        return "$message:\nThe selected videos' dimensions don't match (Reference: $referenceSize; Current: $currentSize)."
     }
 }
 
@@ -56,9 +54,14 @@ class DifferenceGeneratorContainerException(message: String, cause: Throwable? =
  * @param message the detail message.
  * @param cause the cause.
  */
-class DifferenceGeneratorMaskException(message: String, cause: Throwable? = null) : DifferenceGeneratorException(message, cause) {
+class DifferenceGeneratorMaskException(
+    message: String,
+    cause: Throwable? = null,
+    val videoSize: Size,
+    val maskSize: Size,
+) : DifferenceGeneratorException(message, cause) {
     override fun toString(): String {
-        return "MaskException(message=$message, cause=$cause)"
+        return "The selected masks dimensions ($maskSize) don't match the videos' size ($videoSize)."
     }
 }
 

--- a/DifferenceGenerator/src/main/kotlin/mask/CompositeMask.kt
+++ b/DifferenceGenerator/src/main/kotlin/mask/CompositeMask.kt
@@ -1,6 +1,7 @@
 package mask
 
 import DifferenceGeneratorMaskException
+import org.opencv.core.Size
 import java.awt.Graphics2D
 import java.awt.image.BufferedImage
 import java.io.File
@@ -32,7 +33,11 @@ class CompositeMask : Mask {
     constructor(maskFile: File, width: Int, height: Int) {
         maskImage = ImageIO.read(maskFile)
         if (maskImage.width != width || maskImage.height != height) {
-            throw DifferenceGeneratorMaskException("Mask must have the same dimensions as the videos")
+            throw DifferenceGeneratorMaskException(
+                "Mask must have the same dimensions as the videos",
+                videoSize = Size(width.toDouble(), height.toDouble()),
+                maskSize = Size(maskImage.width.toDouble(), maskImage.height.toDouble()),
+            )
         }
     }
 

--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
@@ -102,7 +102,7 @@ private fun calculateVideoDifferences(
         try {
             generator = DifferenceGeneratorWrapper(state)
         } catch (e: DifferenceGeneratorException) {
-            errorDialogText.value = e.message
+            errorDialogText.value = e.toString()
             return@launch
         } catch (e: Exception) {
             errorDialogText.value = "An unexpected exception was thrown when creating" +


### PR DESCRIPTION
Pass video and mask dimensions, and the used and allowed codecs whenever an exception is thrown.

Tackles part of #269 