### PR TITLE
Optimizations

### DIFF
--- a/DifferenceGenerator/src/main/kotlin/util/ColoredFrameGenerator.kt
+++ b/DifferenceGenerator/src/main/kotlin/util/ColoredFrameGenerator.kt
@@ -9,6 +9,17 @@ import java.awt.image.BufferedImage
 
 class ColoredFrameGenerator(val width: Int, val height: Int) {
     val converter = Resettable2DFrameConverter()
+    val coloredFrameBuffer = mutableMapOf<AlignmentElement, Frame>()
+
+    /**
+     * Initializes a new instance of the class.
+     * Caches the colored frames for each [AlignmentElement].
+     */
+    init {
+        for (element in AlignmentElement.values()) {
+            coloredFrameBuffer[element] = getColoredFrame(ColorEncoding.elementToColor[element]!!)
+        }
+    }
 
     /**
      * Creates a colored Frame given a specific [AlignmentElement].
@@ -17,7 +28,7 @@ class ColoredFrameGenerator(val width: Int, val height: Int) {
      * @return a frame colored in the right encoding
      */
     fun getColoredFrame(element: AlignmentElement): Frame {
-        return getColoredFrame(ColorEncoding.elementToColor[element]!!)
+        return coloredFrameBuffer[element]!!
     }
 
     /**


### PR DESCRIPTION
reuse Frames when recording: imporoves Runtime by 6%
![Screenshot_254](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/ecc53a61-7e87-4ee5-b2b8-c67c1f82e104)
![Screenshot_255](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/44074382-3fa0-48d3-8fe8-9cc646a6f371)
