### PR TITLE
Lib2/fix/async pixel diffs

### DIFF
--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     testImplementation(kotlin("test"))
     implementation("org.bytedeco:javacv-platform:1.5.7")
     implementation(project(path = ":VideoGenerator"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-RC")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.1")
 }
 
 tasks.test {

--- a/DifferenceGenerator/build.gradle.kts
+++ b/DifferenceGenerator/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     implementation("org.bytedeco:javacv-platform:1.5.7")
     implementation(project(path = ":VideoGenerator"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-RC")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.1")
 }
 
 tasks.test {

--- a/DifferenceGenerator/src/main/kotlin/algorithms/Gotoh.kt
+++ b/DifferenceGenerator/src/main/kotlin/algorithms/Gotoh.kt
@@ -1,7 +1,9 @@
 package algorithms
 
 import MetricInterface
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import wrappers.ResettableIterable
 
 /**
@@ -101,7 +103,7 @@ class Gotoh<T>(
         // fill the similarity matrix
         runBlocking {
             for (i in 1..m) {
-                launch (Dispatchers.Default) {
+                launch(Dispatchers.Default) {
                     for (j in 1..n) {
                         similarityM[i - 1][j - 1] = 1 - metric.measureDistance(a[i - 1], b[j - 1])
                     }

--- a/DifferenceGenerator/src/main/kotlin/algorithms/Gotoh.kt
+++ b/DifferenceGenerator/src/main/kotlin/algorithms/Gotoh.kt
@@ -1,6 +1,7 @@
 package algorithms
 
 import MetricInterface
+import kotlinx.coroutines.*
 import wrappers.ResettableIterable
 
 /**
@@ -97,6 +98,17 @@ class Gotoh<T>(
         a: ArrayList<T>,
         b: ArrayList<T>,
     ) {
+        // fill the similarity matrix
+        runBlocking {
+            for (i in 1..m) {
+                launch (Dispatchers.Default) {
+                    for (j in 1..n) {
+                        similarityM[i - 1][j - 1] = 1 - metric.measureDistance(a[i - 1], b[j - 1])
+                    }
+                }
+            }
+        }
+
         // main calculation loop, iterating over all rows and columns of the matrices
         for (i in 1..m) {
             for (j in 1..n) {
@@ -121,11 +133,8 @@ class Gotoh<T>(
                         gapB[i][j - 1] + gapExtensionPenalty,
                     )
 
-                // calculate the score for having choosing matching alignment instead of gaps
-                similarityM[i - 1][j - 1] = 1 - metric.measureDistance(a[i - 1], b[j - 1])
                 val similarity = similarityM[i - 1][j - 1]
-                val matchScore =
-                    score[i - 1][j - 1] + similarity // last pair was match and this one too
+                val matchScore = score[i - 1][j - 1] + similarity // two matches in a row
                 val gapAScore = gapA[i - 1][j - 1] + similarity // gap in A and then a match
                 val gapBScore = gapB[i - 1][j - 1] + similarity // gap in B and then a match
 

--- a/GUI/build.gradle.kts
+++ b/GUI/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(project(path = ":DifferenceGenerator"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-RC")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.1")
     // for ui tests
     @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
     testImplementation(compose("org.jetbrains.compose.ui:ui-test-junit4"))

--- a/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
+++ b/GUI/src/main/kotlin/frameNavigation/FrameNavigation.kt
@@ -201,7 +201,7 @@ class FrameNavigation(state: MutableState<AppState>, val scope: CoroutineScope) 
         // set unrealistic goal to force an update
         var goal = -1
         // launch a coroutine to update the bitmaps
-        scope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers.Default) {
             // temp variables to hold the bitmaps and update all at once
             var b1: ImageBitmap? = null
             var b2: ImageBitmap? = null

--- a/GUI/src/main/kotlin/ui/components/general/ProjectManager.kt
+++ b/GUI/src/main/kotlin/ui/components/general/ProjectManager.kt
@@ -64,7 +64,6 @@ fun ProjectMenu(
                     if (state.value.hasUnsavedChanges) {
                         showConfirmationDialog.value = true
                     } else {
-
                         openFileChooserAndGetPath(
                             directoryPath = state.value.openProjectPath,
                             onResult = { path ->

--- a/GUI/src/main/kotlin/ui/components/general/ProjectManager.kt
+++ b/GUI/src/main/kotlin/ui/components/general/ProjectManager.kt
@@ -64,7 +64,7 @@ fun ProjectMenu(
                 },
                 onClick = {
                     openScope.launch(
-                        Dispatchers.IO,
+                        Dispatchers.Default,
                     ) {
                         openFileChooserAndGetPath(
                             directoryPath = state.value.openProjectPath,
@@ -83,7 +83,7 @@ fun ProjectMenu(
                 },
                 onClick = {
                     saveScope.launch(
-                        Dispatchers.IO,
+                        Dispatchers.Default,
                     ) { openFileSaverAndGetPath(state.value.saveProjectPath) { path -> handleSaveProject(state, path) } }
                     expanded = false
                 },

--- a/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
+++ b/GUI/src/main/kotlin/ui/components/selectVideoScreen/ComputeDifferencesButton.kt
@@ -93,7 +93,7 @@ private fun calculateVideoDifferences(
     errorDialogText: MutableState<String?>,
     isLoading: MutableState<Boolean>,
 ) {
-    scope.launch(Dispatchers.IO) {
+    scope.launch(Dispatchers.Default) {
         isLoading.value = true
         AlgorithmExecutionState.getInstance().reset()
 

--- a/GUI/src/main/kotlin/ui/components/settingsScreen/MaskSelectorButton.kt
+++ b/GUI/src/main/kotlin/ui/components/settingsScreen/MaskSelectorButton.kt
@@ -40,7 +40,7 @@ fun RowScope.MaskSelectorButton(
 ) {
     val scope = rememberCoroutineScope()
     Button(
-        onClick = { scope.launch(Dispatchers.IO) { openFileChooserAndGetPath(directoryPath, { path -> onUpdateResult(path) }) } },
+        onClick = { scope.launch(Dispatchers.Default) { openFileChooserAndGetPath(directoryPath, { path -> onUpdateResult(path) }) } },
         shape = MaterialTheme.shapes.medium,
         modifier = Modifier.padding(16.dp).weight(0.6f).fillMaxHeight(0.9f),
     ) {


### PR DESCRIPTION
changed IO blocking to CPU blocking
asynced pixell diff calculation.
the profiler lies:
old Version is 53 seconds:
![Screenshot_263](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/eabd2427-e071-4237-91d9-cda02a6a42b3)
![Screenshot_261](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/9c94f49a-4e13-49a0-a63b-0dc288dc30c7)

the new version is apperently 71 seconds, while the whole calculation is under 50s  ¯\\_(ツ)_/¯:

![Screenshot_268](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/8c752a29-aa10-43d4-8b77-d9c9c8dd72c7)
![Screenshot_264](https://github.com/amosproj/amos2023ws03-gui-frame-diff/assets/96189996/8155a21f-efe9-4b33-a5be-36270d5f5f5a)
